### PR TITLE
Minor updates

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,46 @@
 #!/bin/sh
 
+image="docker.io/antora/antora"
+cmd="--html-url-extension-style=indexify site.yml"
+
 if [ "$(uname)" == "Darwin" ]; then
     # Running on macOS.
     # Let's assume that the user has the Docker CE installed
     # which doesn't require a root password.
-    docker run --rm -it -v $(pwd):/antora antora/antora --html-url-extension-style=indexify site.yml
+    echo ""
+    echo "This build script is using Docker container runtime to run the build in an isolated environment."
+    echo ""
+    docker run -e "ANTORA_DATE=$(date -u)" --rm -it -v $(pwd):/antora $image $cmd
 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     # Running on Linux.
-    # Let's assume that it's running the Docker deamon
+    # Check whether podman is available, else faill back to docker
     # which requires root.
-    echo ""
-    echo "This build script is using Docker to run the build in an isolated environment. You might be asked for a root password in order to start it."
-sudo docker run --rm -it -v $(pwd):/antora:z antora/antora --html-url-extension-style=indexify site.yml
+
+    if [ -f /usr/bin/podman ]; then
+        echo ""
+        echo "This build script is using Podman to run the build in an isolated environment."
+        echo ""
+	podman run -e "ANTORA_DATE=$(date -u)" --rm -it -v $(pwd):/antora:z $image $cmd
+
+    elif [ -f /usr/bin/docker ]; then
+        echo ""
+        echo "This build script is using Docker to run the build in an isolated environment."
+        echo ""
+
+        if groups | grep -wq "docker"; then
+	    docker run -e "ANTORA_DATE=$(date -u)" --rm -it -v $(pwd):/antora:z $image $cmd
+	else
+            echo ""
+            echo "This build script is using $runtime to run the build in an isolated environment. You might be asked for your password."
+            echo "You can avoid this by adding your user to the 'docker' group, but be aware of the security implications. See https://docs.docker.com/install/linux/linux-postinstall/."
+            echo ""
+            sudo docker run -e "ANTORA_DATE=$(date -u)" --rm -it -v $(pwd):/antora:z $image $cmd
+	fi
+    else
+        echo ""
+	echo "Error: Container runtime haven't been found on your system. Fix it by:"
+	echo "$ sudo dnf install podman"
+	exit 1
+    fi
 fi

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,3 +1,2 @@
-* xref:introduction.adoc[Introduction]
-** xref:getting-started.adoc[Getting Started]
+* xref:getting-started.adoc[Getting Started]
 * xref:faq.adoc[FAQ]

--- a/modules/ROOT/pages/architecture.adoc
+++ b/modules/ROOT/pages/architecture.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Fedora CoreOS Architecture

--- a/modules/ROOT/pages/cheatsheets.adoc
+++ b/modules/ROOT/pages/cheatsheets.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Cheat Sheets

--- a/modules/ROOT/pages/configuration.adoc
+++ b/modules/ROOT/pages/configuration.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Configuration
 
 * link:systemd.adoc[systemd-*]

--- a/modules/ROOT/pages/containerruntimes.adoc
+++ b/modules/ROOT/pages/containerruntimes.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Container Runtimes
 
 [[docker]]

--- a/modules/ROOT/pages/containers.adoc
+++ b/modules/ROOT/pages/containers.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Working with Containers

--- a/modules/ROOT/pages/developerguides.adoc
+++ b/modules/ROOT/pages/developerguides.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Developer Guides

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Fedora CoreOS Frequently Asked Questions
 
 If you have other questions than are mentioned here or want to discuss

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,4 +1,4 @@
-== Fedora CoreOS Frequently Asked Questions
+= Fedora CoreOS Frequently Asked Questions
 
 If you have other questions than are mentioned here or want to discuss
 further, join us in our IRC channel,
@@ -7,7 +7,7 @@ https://discussion.fedoraproject.org/c/server/coreos[discussion board].
 Please refer back here as some questions and answers will likely get
 updated.
 
-=== What is Fedora CoreOS?
+== What is Fedora CoreOS?
 
 Fedora CoreOS is an automatically updating, minimal, monolithic,
 container-focused operating system, designed for clusters but also
@@ -20,7 +20,7 @@ securely and at scale.
 
 https://discussion.fedoraproject.org/t/launch-faq-what-is-fedora-coreos/40[discuss]
 
-=== How does Fedora CoreOS relate to Red Hat CoreOS?
+== How does Fedora CoreOS relate to Red Hat CoreOS?
 
 Fedora CoreOS is a freely available, community distribution that is the
 upstream basis for Red Hat CoreOS. While Fedora CoreOS will embrace a
@@ -30,7 +30,7 @@ with the platform.
 
 https://discussion.fedoraproject.org/t/launch-faq-how-does-fedora-coreos-relate-to-red-hat-coreos/41[discuss]
 
-=== Does Fedora CoreOS replace Container Linux? What happens to CL?
+== Does Fedora CoreOS replace Container Linux? What happens to CL?
 
 Fedora CoreOS will eventually become the successor to Container Linux.
 The Container Linux project has a large installed base - it is a top
@@ -42,7 +42,7 @@ parallel, in a non-disruptive way.
 
 https://discussion.fedoraproject.org/t/launch-faq-does-fedora-coreos-replace-container-linux-what-happens-to-cl/42[discuss]
 
-=== Does Fedora CoreOS replace Fedora Atomic Host? What happens to Fedora Atomic Host and CentOS Atomic Host?
+== Does Fedora CoreOS replace Fedora Atomic Host? What happens to Fedora Atomic Host and CentOS Atomic Host?
 
 Fedora CoreOS will also become the successor to Fedora Atomic Host. The
 current plan is for Fedora Atomic Host to have at least a 29 version and

--- a/modules/ROOT/pages/first-boot.adoc
+++ b/modules/ROOT/pages/first-boot.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = First Boot Provisioning

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Fedora CoreOS - Getting Started
 
 Fedora CoreOS has no install-time configuration. Every Fedora CoreOS system begins with a generic, unconfigured disk image. On first boot Ignition will read the supplied config and configure the system. Ignition configs are usually supplied via the cloud’s userdata mechanism, or, in the case of bare metal, injected at install time. This guide will show you how to launch Fedora CoreOS on AWS, QEMU, and bare metal as well as how to create Ignition configs.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,18 +1,18 @@
-== Fedora CoreOS - Getting Started
+= Fedora CoreOS - Getting Started
 
 Fedora CoreOS has no install-time configuration. Every Fedora CoreOS system begins with a generic, unconfigured disk image. On first boot Ignition will read the supplied config and configure the system. Ignition configs are usually supplied via the cloud’s userdata mechanism, or, in the case of bare metal, injected at install time. This guide will show you how to launch Fedora CoreOS on AWS, QEMU, and bare metal as well as how to create Ignition configs.
 
-=== Launching Fedora CoreOS
+== Launching Fedora CoreOS
 
-==== Booting on AWS
+=== Booting on AWS
 
 To boot on AWS, find the correct AMI in the https://getfedora.org/coreos/download/[download page] and specify the Ignition config as the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user-data]. Note that while the AWS documentation mentions cloud-init and scripts, Fedora CoreOS only accepts Ignition configs; it does not support cloud-init or running scripts from userdata.
 
 .Example launching Fedora CoreOS on AWS
 [source, bash]
-aws ec2 run-instances <other options> --user-data file://config.ign 
+aws ec2 run-instances <other options> --user-data file://config.ign
 
-==== Booting with QEMU
+=== Booting with QEMU
 
 Download the QEMU Fedora CoreOS image from the https://getfedora.org/coreos/download/[download page].
 
@@ -25,11 +25,11 @@ qemu-system-x86_64 -machine accel=kvm -m 2048 -cpu host -nographic \
 	-device virtio-rng-pci \
 	-fw_cfg name=opt/com.coreos/config,file=path/to/ignition-config.ign
 
-==== Installing on bare metal
+=== Installing on bare metal
 
 Follow the https://github.com/coreos/coreos-installer/[coreos-installer instructions] to install Fedora CoreOS to disk. This will inject your specified Ignition config in the installed image.
 
-=== Generating Ignition configs
+== Generating Ignition configs
 
 Ignition configs are not intended to be hand-written. Instead, use the https://github.com/coreos/fcct[Fedora CoreOS Config Transpiler (FCCT)] to translate Fedora CoreOS Configs (FCCs) to Ignition configs. In addition to be easier to write, FCCT will also validate your config and check for errors. Here’s an example FCC that adds an SSH key to the `core` user’s authorized keys:
 
@@ -56,7 +56,7 @@ ssh core@<ip>
 
 Refer to the FCCT https://github.com/coreos/fcct/blob/master/docs/getting-started.md[getting started guide], https://github.com/coreos/fcct/blob/master/docs/examples.md[examples] and https://github.com/coreos/fcct/blob/master/docs/configuration-v1_0.md[configuration specification] for more information on using FCCT, more examples, and a complete list of configuration FCCT supports.
 
-==== Running containers
+=== Running containers
 
 Fedora CoreOS ships with both docker and podman installed. Use systemd units to start and stop containers.
 
@@ -72,21 +72,21 @@ systemd:
       contents: |
         [Unit]
         Description=MyApp
-        
+
         [Service]
         TimeoutStartSec=0
         ExecStartPre=-/bin/podman kill busybox1
         ExecStartPre=-/bin/podman rm busybox1
         ExecStartPre=/bin/podman pull busybox
         ExecStart=/bin/podman run --name busybox1 busybox /bin/sh -c "trap 'exit 0' INT TERM; while true; do echo Hello World; sleep 1; done"
-        
+
         [Install]
         WantedBy=multi-user.target
 ----
 
 Note that when using docker instead of podman, units starting docker containers will need `Requires=docker.service` and `After=docker.service` to ensure the docker daemon is running before trying to start containers.
 
-==== Running etcd
+=== Running etcd
 
 etcd is not shipped as part of Fedora CoreOS and should instead be run as a container.
 
@@ -102,7 +102,7 @@ systemd:
       contents: |
         [Unit]
         Description=Run single node etcd
-        
+
         [Service]
         ExecStartPre=mkdir -p /var/lib/etcd
         ExecStartPre=-/bin/podman kill etcd
@@ -115,13 +115,13 @@ systemd:
                 --initial-cluster node1=http://127.0.0.1:2380
 
         ExecStop=/bin/podman stop etcd
-        
+
         [Install]
         WantedBy=multi-user.target
 ----
 
 See the https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/container.md#docker[etcd documentation] for more information on running etcd in containers and how to set up multi-node etcd.
 
-=== Where to report bugs and ask questions
+== Where to report bugs and ask questions
 
 Report bugs to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker] and ask questions on the `#fedora-coreos` IRC channel on freenode or on the https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[Fedora CoreOS mailing list].

--- a/modules/ROOT/pages/guides.adoc
+++ b/modules/ROOT/pages/guides.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Use Case and Developer Guides
 
 * link:developerguides.adoc[Developers]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Fedora CoreOS Documentation
 
 Welcome to the Fedora CoreOS documentation!

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -2,3 +2,19 @@
 = Fedora CoreOS Documentation
 
 Welcome to the Fedora CoreOS documentation!
+
+[NOTE]
+====
+This site and project are currently very dynamic and will change a lot within the next weeks and months.
+Please refer to the xref:faq.adoc[FAQ] for more information for the time being.
+ If you want to help or ask any questions, join the link:irc://irc.freenode.org/#fedora-coreos[IRC channel], or join our new link:https://discussion.fedoraproject.org/c/server/coreos[discussion board].
+====
+
+image::welcomefedoracoreos.jpg[]
+
+Fedora CoreOS is an automatically updating, minimal, monolithic, container-focused operating system, designed for clusters but also operable standalone, optimized for Kubernetes but also great without it.
+It aims to combine the best of both CoreOS Container Linux and Fedora Atomic Host, integrating technology like Ignition from Container Linux with rpm-ostree and SELinux hardening from Project Atomic.
+Its goal is to provide the best container host to run containerized workloads securely and at scale.
+
+Fedora CoreOS is an open source project associated with the link:https://fedoraproject.org/[Fedora Project].
+We are aiming for high compatibility with existing Container Linux configuration and user experience, and we expect to provide documentation and tooling to help migrate from Container Linux to Fedora CoreOS.

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Installation Guide
 
 This installation guide aims at helping you link:first-boot.adoc[provision your first boot] as well as explain how to boot on the various platforms.

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -1,3 +1,4 @@
+:experimental:
 = Welcome to Fedora CoreOS!
 
 == What is Fedora CoreOS?

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -1,3 +1,3 @@
-= Introduction
+= Welcome to Fedora CoreOS!
 
 == What is Fedora CoreOS?

--- a/modules/ROOT/pages/introduction.adoc
+++ b/modules/ROOT/pages/introduction.adoc
@@ -1,4 +1,0 @@
-:experimental:
-= Welcome to Fedora CoreOS!
-
-== What is Fedora CoreOS?

--- a/modules/ROOT/pages/maintenance.adoc
+++ b/modules/ROOT/pages/maintenance.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Maintaining Your CoreOS

--- a/modules/ROOT/pages/network.adoc
+++ b/modules/ROOT/pages/network.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Network Configuration

--- a/modules/ROOT/pages/rollbacks.adoc
+++ b/modules/ROOT/pages/rollbacks.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Rollbacks

--- a/modules/ROOT/pages/systemd.adoc
+++ b/modules/ROOT/pages/systemd.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = systemd-*

--- a/modules/ROOT/pages/updates.adoc
+++ b/modules/ROOT/pages/updates.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Updates

--- a/modules/ROOT/pages/usecaseguides.adoc
+++ b/modules/ROOT/pages/usecaseguides.adoc
@@ -1,1 +1,2 @@
+:experimental:
 = Use Cases

--- a/preview.sh
+++ b/preview.sh
@@ -5,14 +5,14 @@ if [ "$(uname)" == "Darwin" ]; then
     # Let's assume that the user has the Docker CE installed
     # which doesn't require a root password.
     echo "The preview will be available at http://localhost:8080/"
-    docker run --rm -v $(pwd)/public:/usr/share/nginx/html:ro -p 8080:80 nginx
+    docker run --rm -v $(pwd):/antora:ro -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro -p 8080:80 nginx
 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     # Running on Linux.
-    # Let's assume that it's running the Docker deamon
-    # which requires root.
+    # Fedora Workstation has python3 installed as a default, so using that
     echo ""
-    echo "This build script is using Docker to run the build in an isolated environment. You might be asked for a root password in order to start it."
-    echo "The preview will be available at http://localhost:8080/"
-    sudo docker run --rm -v $(pwd)/public:/usr/share/nginx/html:ro -p 8080:80 nginx
+    echo "The preview is available at http://localhost:8080"
+    echo ""
+    cd ./public
+    python3 -m http.server 8080
 fi


### PR DESCRIPTION
I took the liberty of making some updates.

* The build and preview scripts were outdated so I replaced them with the latest version which defaults to podman (which allows them to run without `sudo`) but can use docker as well if podman isn't available.
* Fixed titles on each page; some of them were starting at level 2 (`==`) instead of 1 (`=`), which was causing some pages to have "Untitled" in the rendered page title.
* Added the `:experimental:` attribute to each page; this allows you to use some additional markup such as `kbd:[]`.
* Removed the Introduction page, because introductory information is best placed in the index - that's the first thing the user sees
* Copied text explaining what CoreOS is from the website (https://coreos.fedoraproject.org/) to the index, including the image that was in `assets/` but not included anywhere.

There are also a bunch of unused source files in the repo but I'm assuming you're aware of that and working on updates that would reinclude them.