### PR TITLE
bug: Correct markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fedora Docs Template
 
-This repository contains the Fedora CoreOS documentation. The format is (https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/)[AsciiDoc] to enable integration into the official (https://docs.fedoraproject.org/en-US/docs/)[Fedora documentation].
+This repository contains the Fedora CoreOS documentation. The format is [AsciiDoc](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) to enable integration into the official [Fedora documentation](https://docs.fedoraproject.org/en-US/docs/).
 
 ## Structure
 


### PR DESCRIPTION
The markdown links in the premble of the README.md place the link before
the content on the href.  This commit normalizes the order to the
correct syntax.