### PR TITLE
pages/getting-started: modify example unit file to start after network-online target.

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -84,6 +84,8 @@ systemd:
       contents: |
         [Unit]
         Description=MyApp
+        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         TimeoutStartSec=0
@@ -114,6 +116,8 @@ systemd:
       contents: |
         [Unit]
         Description=Run single node etcd
+        After=network-online.target
+        Wants=network-online.target
 
         [Service]
         ExecStartPre=mkdir -p /var/lib/etcd


### PR DESCRIPTION
Adds `After=network-online.target` to the example systemd unit file so that it only starts the container after networking has started. Otherwise the container would not start on boot.