### PR TITLE
scripts: fix interpreter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 image="docker.io/antora/antora"
 cmd="--html-url-extension-style=indexify site.yml"

--- a/preview.sh
+++ b/preview.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
     # Running on macOS.


### PR DESCRIPTION
The scripts in here use bash-specific extensions. This fixes the
shebang to match that.