### PR TITLE
pages/platforms: update ibmcloud specs

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -26,7 +26,7 @@ Here is a list of all supported platforms and their identifier:
  * `aws`: Amazon Web Services (cloud platform)
  * `azure`: Microsoft Azure (cloud platform)
  * `gcp`: Google Cloud Platform (cloud platform)
- * `ibmcloud`: IBM Cloud (cloud platform)
+ * `ibmcloud`: IBM Cloud, VPC Generation 2 (cloud platform)
  * `metal`: bare metal with BIOS or UEFI boot
  * `openstack`: OpenStack (cloud platform)
  * `qemu`: QEMU (hypervisor)


### PR DESCRIPTION
This clarifies `ibmcloud` specs, scoping to VPC Generation 2 only
(for the moment).

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/277#issuecomment-548710113