### PR TITLE
getting-started: provide path for running without Ignition config

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,9 +1,9 @@
 :experimental:
 = Fedora CoreOS - Getting Started
 
-Fedora CoreOS (FCOS) has no install-time configuration. Every FCOS system begins with a generic disk image. For each deployment mechanism (cloud VM, local VM, bare metal), the configuration must be supplied at first boot. FCOS reads the configuration file with https://github.com/coreos/ignition[Ignition]. For cloud deployments, Ignition gathers the configuration via the cloud’s user-data mechanism. In the case of bare metal, Ignition injects the configuration at install time.
+Fedora CoreOS (FCOS) has no install-time configuration. Every FCOS system begins with a generic disk image. For each deployment mechanism (cloud VM, local VM, bare metal), configuration can be supplied at first boot. FCOS reads and applies the configuration file with https://github.com/coreos/ignition[Ignition]. For cloud deployments, Ignition gathers the configuration via the cloud’s user-data mechanism. In the case of bare metal, Ignition injects the configuration at install time.
 
-NOTE: To launch FCOS, you must provide an Ignition configuration file. Refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
+NOTE: For more information on configuration, refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
 
 == Launching FCOS
 
@@ -13,13 +13,18 @@ To launch FCOS on AWS:
 
 . Go to the https://getfedora.org/coreos/download/[download page] to identify the correct AMI.
 
-. Specify the Ignition configuration file as the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user-data].
+. Specify the Ignition configuration file as the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user-data]. You can skip this step, but you will want to specify a key using `--key-name` so that you can still access the node. This provides an easy way to test out FCOS without first creating an Ignition configuration.
 
-
-.Example launching Fedora CoreOS on AWS
+.Example launching Fedora CoreOS on AWS using an Ignition configuration file
 [source, bash]
 ----
 aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
+----
+
+.Example launching Fedora CoreOS on AWS using a registered SSH key pair
+[source, bash]
+----
+aws ec2 run-instances <other options> --image-id <ami> --key-name my-key
 ----
 
 While the AWS documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -18,3 +18,5 @@ Its goal is to provide the best container host to run containerized workloads se
 
 Fedora CoreOS is an open source project associated with the link:https://fedoraproject.org/[Fedora Project].
 We are aiming for high compatibility with existing Container Linux configuration and user experience, and we expect to provide documentation and tooling to help migrate from Container Linux to Fedora CoreOS.
+
+xref:getting-started.adoc[Get started using Fedora CoreOS!]


### PR DESCRIPTION
To lower the barrier a bit more on trying FCOS, tweak the AWS docs to
clarify that one doesn't *have* to specify an Ignition config. Provide
an example using `--key-name`.

There's also the live image... we should document that too at some
point.

This came out of feedback from a Reddit comment:
https://www.reddit.com/r/Fedora/comments/epyzbx/fedora_coreos_out_of_preview/feoysmk