### PR TITLE
Various fcct usage updates

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -47,11 +47,11 @@ An easy way to use `fcct` is to run it in a container with `podman`:
 
 . Pull the container for `fcct`:
 +
-`podman pull quay.io/coreos/fcct:v0.2.0`
+`podman pull quay.io/coreos/fcct:release`
 +
 . Run fcct on the FCC file:
 +
-`podman run -i --rm quay.io/coreos/fcct:v0.2.0 -pretty -strict < example.fcc > example.ign`
+`podman run -i --rm quay.io/coreos/fcct:release -pretty -strict < example.fcc > example.ign`
 +
 . Use the `example.ign` file to xref:getting-started.adoc[boot FCOS].
 

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -51,7 +51,7 @@ An easy way to use `fcct` is to run it in a container with `podman`:
 +
 . Run fcct on the FCC file:
 +
-`podman run -i --rm quay.io/coreos/fcct:release -pretty -strict < example.fcc > example.ign`
+`podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < example.fcc > example.ign`
 +
 . Use the `example.ign` file to xref:getting-started.adoc[boot FCOS].
 

--- a/modules/ROOT/pages/using-fcct.adoc
+++ b/modules/ROOT/pages/using-fcct.adoc
@@ -20,10 +20,10 @@ This example uses podman, but you can use docker in a similar manner. Note that 
 . Run `fcct` either by using standard in and standard out or by using files. Refer to the examples below.
 +
 .Example running `fcct` using standard in and standard out:
-`podman run -i --rm quay.io/coreos/fcct:release -pretty -strict < your_config.fcc > transpiled_config.ign`
+`podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < your_config.fcc > transpiled_config.ign`
 +
 .Example running `fcct` using files:
-`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release -pretty -strict -input /config.fcc > transpiled_config.ign`
+`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict --input /config.fcc > transpiled_config.ign`
 +
 NOTE: `fcct` sends its output to `stdout`, so the examples above pipe that output to a file named `transpiled_config.ign`.
 

--- a/modules/ROOT/pages/using-fcct.adoc
+++ b/modules/ROOT/pages/using-fcct.adoc
@@ -30,7 +30,7 @@ NOTE: `fcct` sends its output to `stdout`, so the examples above pipe that outpu
 === Standalone binary
 To use the `fcct` binary on Linux, follow these steps:
 
-. If you have not already done so, download the http://coreos.com/security/app-signing-key/[CoreOS Application Signing Key] and import it: `gpg --import <key>`
+. If you have not already done so, download the https://getfedora.org/static/fedora.gpg[Fedora signing keys] and import them: `gpg --import <key>`
 +
 . Download the latest version of `fcct` and the detached signature from the https://github.com/coreos/fcct/releases[releases page].
 . Verify it with gpg: `gpg --verify <detached sig> <fcct binary>`

--- a/modules/ROOT/pages/using-fcct.adoc
+++ b/modules/ROOT/pages/using-fcct.adoc
@@ -13,19 +13,17 @@ You can run `fcct` as a container with docker or podman or download it as a stan
 
 === Container
 
-This example uses podman, but you can use docker in a similar manner.
+This example uses podman, but you can use docker in a similar manner. Note that the `release` tag tracks the most recent release, and the `latest` tag tracks the Git development branch.
 
-In this example, substitute `v0.2.0` with the desired version, as the `latest` tag corresponds with `master` and not with the latest release.
-
-. Pull the container: `podman pull quay.io/coreos/fcct:v0.2.0`
+. Pull the container: `podman pull quay.io/coreos/fcct:release`
 
 . Run `fcct` either by using standard in and standard out or by using files. Refer to the examples below.
 +
 .Example running `fcct` using standard in and standard out:
-`podman run -i --rm quay.io/coreos/fcct:v0.2.0 -pretty -strict < your_config.fcc > transpiled_config.ign`
+`podman run -i --rm quay.io/coreos/fcct:release -pretty -strict < your_config.fcc > transpiled_config.ign`
 +
 .Example running `fcct` using files:
-`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:v0.2.0 -pretty -strict -input /config.fcc > transpiled_config.ign`
+`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release -pretty -strict -input /config.fcc > transpiled_config.ign`
 +
 NOTE: `fcct` sends its output to `stdout`, so the examples above pipe that output to a file named `transpiled_config.ign`.
 


### PR DESCRIPTION
The last commit depends on https://github.com/coreos/fcct/pull/72 and the second-to-last one should probably not happen without https://github.com/coreos/fcct/pull/70.