### PR TITLE
nav: add back platforms link

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -13,4 +13,4 @@
 ** Troubleshooting
 *** xref:manual-rollbacks.adoc[Manual Rollbacks]
 * Reference pages
-// ** xref:platforms.adoc[Platforms]
+ ** xref:platforms.adoc[Platforms]


### PR DESCRIPTION
This adds back a navigation link to the platform reference page,
which is otherwise orphan.