### PR TITLE
platforms: allocate ID for vultr

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -31,3 +31,4 @@ Here is a list of all supported platforms and their identifier:
  * `openstack`: OpenStack (cloud platform)
  * `qemu`: QEMU (hypervisor)
  * `vmware`: VMware ESXi (hypervisor - requires hardware version 13 or later, see https://kb.vmware.com/s/article/1003746)
+ * `vultr`: Vultr (cloud platform)


### PR DESCRIPTION
This adds `vultr` as the platform ID for Vultr cloud provider.

Homepage: https://www.vultr.com/
Metadata: https://www.vultr.com/metadata
User data: https://web.archive.org/web/20190513194756/https://www.vultr.com/metadata/#user