### PR TITLE
using-fcct: drop deprecated --input option

### DIFF
--- a/modules/ROOT/pages/using-fcct.adoc
+++ b/modules/ROOT/pages/using-fcct.adoc
@@ -23,7 +23,7 @@ This example uses podman, but you can use docker in a similar manner. Note that 
 `podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < your_config.fcc > transpiled_config.ign`
 +
 .Example running `fcct` using files:
-`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict --input /config.fcc > transpiled_config.ign`
+`podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict /config.fcc > transpiled_config.ign`
 +
 NOTE: `fcct` sends its output to `stdout`, so the examples above pipe that output to a file named `transpiled_config.ign`.
 


### PR DESCRIPTION
Depends on https://github.com/coreos/fcct/pull/72 and https://github.com/coreos/fedora-coreos-docs/pull/35.