### PR TITLE
migrate-ah: tweak wording for translating configs instruction

### DIFF
--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -23,7 +23,7 @@ ssh_authorized_keys:
   - ssh-rsa ...
 ----
 
-Manually configure with a xref:ign-passwd.adoc[`passwd`] node in the FCC file:
+This can be manually translated into a xref:ign-passwd.adoc[`passwd`] node within the FCC file:
 
 .Example of users:
 [source, yaml]


### PR DESCRIPTION
I believe "Manually configure" is a little less clear about
what needs to be done. Where "This can be manually translated"
seems to be a little better.