### PR TITLE
getting-started: link to FCOS Discourse forum

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -85,4 +85,4 @@ Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install
 
 == Where to report bugs and ask questions
 
-Report bugs to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker] and ask questions on the `#fedora-coreos` IRC channel on freenode or on the https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[Fedora CoreOS mailing list].
+Report bugs to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker] and ask questions on the `#fedora-coreos` IRC channel on freenode, the https://discussion.fedoraproject.org/c/server/coreos/[Fedora CoreOS forum], or the https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[mailing list].


### PR DESCRIPTION
We link to it on the main docs page already, though it's useful here too
in this section.