### PR TITLE
[DRAFT] platforms: allocate ID for ibmcloud-classic

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -27,6 +27,7 @@ Here is a list of all supported platforms and their identifier:
  * `azure`: Microsoft Azure (cloud platform)
  * `gcp`: Google Cloud Platform (cloud platform)
  * `ibmcloud`: IBM Cloud, VPC Generation 2 (cloud platform)
+ * `ibmcloud-classic`: IBM Cloud, Classic (cloud platform)
  * `metal`: bare metal with BIOS or UEFI boot
  * `openstack`: OpenStack (cloud platform)
  * `qemu`: QEMU (hypervisor)


### PR DESCRIPTION
DRAFT: it is unclear whether we want to provide RHCOS/FCOS on Classic instances, due to overall limitations of Classic infrastructure. Just claiming a placeholder ID for now.

---

This adds `ibmcloud-classic` as the platform ID for IBM Cloud
Classic instances.

Ref: https://github.com/coreos/coreos-assembler/issues/1119#issuecomment-584539165