### PR TITLE
Add some troubleshooting steps for access recovery

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -15,5 +15,6 @@
 *** xref:auto-updates.adoc[Auto-Updates]
 ** Troubleshooting
 *** xref:manual-rollbacks.adoc[Manual Rollbacks]
+*** xref:access-recovery.adoc[Access Recovery]
 * Reference pages
  ** xref:platforms.adoc[Platforms]

--- a/modules/ROOT/pages/access-recovery.adoc
+++ b/modules/ROOT/pages/access-recovery.adoc
@@ -1,0 +1,10 @@
+= Access Recovery
+
+If you've lost the private key of an SSH keypair used to log into Fedora CoreOS, and do not have any password logins set up to use at the console, you can gain access back to the machine using the `init=/bin/sh` trick:
+
+. When booting the system, intercept the GRUB menu and edit the entry to append `init=/bin/sh` to the kernel argument list, then press Ctrl-X to resume booting.
+. Once the system has booted into a shell prompt, load the SELinux policy with `/sbin/load_policy -i`. If you miss this step before running `passwd`, you'll want to run `/sbin/restorecon -v /etc/{passwd,shadow}` before rebooting.
+. Set or reset the password for the target user using the `passwd` utility.
+. And finally, reboot the system with `/sbin/reboot -f`.
+
+You should now be able to log back into the system at the console. From there, you can e.g. fetch a new public SSH key to add to `~/.ssh/authorized_keys` and delete the old one. You may also want to lock the password you've set (using `passwd -l`). Note that Fedora CoreOS by default does not allow SSH login via password authentication.

--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -37,6 +37,8 @@ passwd:
       groups: [ sudo, docker ]
 ----
 
+NOTE: Fedora CoreOS disables password login over SSH by default. It is strongly recommended to only use key authentication. Setting passwords can be useful however for logging into the console directly.
+
 == Converting storage definitions
 
 With FAH, you could configure additional storage for the system with either `cloud-init` or  `docker-storage-setup` via the `/etc/sysconfig/docker-storage-setup` file. With FCOS, you should configure additional storage at provisioning time via Ignition in the xref:ign-storage.adoc[`storage`] node of the FCC file.

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -14,7 +14,7 @@ To migrate from CL to FCOS, you must convert your old Container Linux Configs, I
 The following changes have been made to the installation process:
 
 * The `coreos-install` script has been replaced with https://github.com/coreos/coreos-installer[`coreos-installer`]. It offers similar functionality.
-* The `coreos.autologin` kernel command-line parameter is not currently supported in FCOS.
+* The `coreos.autologin` kernel command-line parameter is not currently supported in FCOS. For access recovery purposes, there are instructions available xref:access-recovery.adoc[here].
 * Certain CL platforms, such as Vagrant, are not yet supported in FCOS. Refer to the https://getfedora.org/coreos/download/[Download page] to see the available image types.
 
 == Software package changes


### PR DESCRIPTION
The `init=/bin/sh` trick is known, but let's give a clear step-by-step
to make this easier. (The SELinux step in particular is easy to miss.)

See related user question:
https://discussion.fedoraproject.org/t/recommended-password-recovery-procedure/17034