### PR TITLE
platforms: allocate ID for Exoscale

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -25,6 +25,7 @@ Here is a list of all supported platforms and their identifier:
  * `aliyun`: Aliyun/Alibaba Cloud (cloud platform)
  * `aws`: Amazon Web Services (cloud platform)
  * `azure`: Microsoft Azure (cloud platform)
+ * `exoscale`: Exoscale (cloud platform)
  * `gcp`: Google Cloud Platform (cloud platform)
  * `ibmcloud`: IBM Cloud, VPC Generation 2 (cloud platform)
  * `metal`: bare metal with BIOS or UEFI boot


### PR DESCRIPTION
This adds `exoscale` as the platform ID for Exoscale cloud provider

Homepage: https://www.exoscale.com/
User data and meta data: https://community.exoscale.com/documentation/compute/cloud-init/#querying-the-user-data-and-meta-data-from-the-instance

https://github.com/coreos/fedora-coreos-tracker/issues/384