### PR TITLE
Split AWS/qemu instructions out of getting-started to their own pages

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -5,6 +5,7 @@
 ** xref:faq.adoc[FAQ]
 ** xref:migrate-cl.adoc[Migrating from Container Linux]
 ** Provisioning Machines
+*** xref:provisioning-aws.adoc[Booting on AWS]
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
 *** xref:provisioning-vmware.adoc[Booting on VMware]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 *** xref:provisioning-aws.adoc[Booting on AWS]
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
+*** xref:provisioning-qemu.adoc[Booting on QEMU]
 *** xref:provisioning-vmware.adoc[Booting on VMware]
 ** System Configuration
 *** xref:producing-ign.adoc[Producing an Ignition File]

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -7,56 +7,6 @@ NOTE: For more information on configuration, refer to the documentation for xref
 
 == Launching FCOS
 
-=== Launching with QEMU or libvirt
-. https://getfedora.org/coreos/download/[Download and verify] the latest image suitable for QEMU.
-
-. Uncompress the file. Assuming that the downloaded file is called `fedora-coreos-qemu.qcow2.xz`, the command would be the following:
-+
-[source, bash]
-----
-unxz fedora-coreos-qemu.qcow2.xz
-----
-+
-TIP: Make sure that your user has access to `/dev/kvm` (this should already be the case on modern distros), or if `/dev/kvm` is owned by the `kvm` group, adding yourself to that group with `usermod -aG kvm $USER`.
-
-. Launch the VM using `qemu-kvm` or `virt-install`. The Ignition file is passed to the VM via the `-fw_cfg` parameter, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device. For libvirt, you must pass this through the `--qemu-commandline` argument. You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM, or `qemu-img create` to first create a layered qcow2.
-+
-.Example launching FCOS with QEMU (temporary storage)
-[source, bash]
-----
-qemu-kvm -m 2048 -cpu host -nographic -snapshot \
-	-drive if=virtio,file=fedora-coreos-qemu.qcow2 \
-	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign
-----
-+
-.Example launching FCOS with QEMU (persistent storage)
-[source, bash]
-----
-qemu-img create -f qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
-qemu-kvm -m 2048 -cpu host -nographic \
-	-drive if=virtio,file=my-fcos-vm.qcow2 \
-	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign
-----
-+
-.Example launching FCOS with virt-install
-[source, bash]
-----
-virt-install --connect qemu:///system -n fcos -r 2048 --os-variant=fedora31 --import \
-	--graphics=none --disk size=10,backing_store=/path/to/fedora-coreos-qemu.qcow2 \
-	--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=/path/to/example.ign"
-----
-
-NOTE: When using `virt-install`, you must specify absolute paths to the image and the Ignition file.
-
-TIP: If running with SELinux enabled, you may need to change the label of the Ignition file to allow access: `chcon -t svirt_home_t path/to/example.ign`
-
-Once the VM has finished booting, its IP addresses will appear on the serial console. You can then SSH into the FCOS VM as the `core` user:
-
-[source, bash]
-----
-ssh core@<ip address>
-----
-
 == Installing on bare metal
 
 Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install Fedora CoreOS to disk. This procedure injects the specified Ignition configuration at install time.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -7,9 +7,17 @@ NOTE: For more information on configuration, refer to the documentation for xref
 
 == Launching FCOS
 
+=== Launching in a cloud
+
+Follow the corresponding guide for xref:provisioning-aws.adoc[Amazon Web Services], xref:provisioning-azure.adoc[Azure], or xref:provisioning-digitalocean.adoc[DigitalOcean] to launch an instance of Fedora CoreOS.
+
+=== Launching in a virtual machine hypervisor
+
+Follow the corresponding guide for xref:provisioning-qemu.adoc[QEMU or libvirt] or xref:provisioning-vmware.adoc[VMware] to launch an instance of Fedora CoreOS.
+
 == Installing on bare metal
 
-Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install Fedora CoreOS to disk. This procedure injects the specified Ignition configuration at install time.
+Follow the xref:bare-metal.adoc[bare metal installation instructions] to install Fedora CoreOS to disk. This procedure injects the specified Ignition configuration at install time.
 
 == Where to report bugs and ask questions
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -7,28 +7,6 @@ NOTE: For more information on configuration, refer to the documentation for xref
 
 == Launching FCOS
 
-=== Launching on Amazon Web Services (AWS)
-
-To launch FCOS on AWS:
-
-. Identify the correct AMI image ID for your region from https://getfedora.org/coreos/download/[the download page]
-
-. Launch the VM using `aws ec2 run-instances`. The Ignition file can be passed to the VM as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data]. You can skip this step if you just want SSH access; simply pass a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered key name] via `--key-name`. This provides an easy way to test out FCOS without first creating an Ignition configuration.
-+
-.Example launching FCOS on AWS using an Ignition configuration file
-[source, bash]
-----
-aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
-----
-+
-.Example launching FCOS on AWS using a registered SSH key pair
-[source, bash]
-----
-aws ec2 run-instances <other options> --image-id <ami> --key-name my-key
-----
-+
-While the AWS documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.
-
 === Launching with QEMU or libvirt
 . https://getfedora.org/coreos/download/[Download and verify] the latest image suitable for QEMU.
 

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -1,0 +1,29 @@
+= Provisioning Fedora CoreOS on AWS
+
+This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Amazon Web Services (AWS).
+
+== Prerequisites
+
+Before provisioning a FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to an AWS account.  The examples below use the https://aws.amazon.com/cli/[AWS CLI].
+
+== Launching a VM instance
+
+. Identify the correct AMI image ID for your region from https://getfedora.org/coreos/download/[the download page]
+
+. Launch the VM using `aws ec2 run-instances`. The Ignition file can be passed to the VM as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data]. You can skip this step if you just want SSH access; simply pass a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered key name] via `--key-name`. This provides an easy way to test out FCOS without first creating an Ignition configuration.
++
+.Example launching FCOS on AWS using an Ignition configuration file
+[source, bash]
+----
+aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
+----
++
+.Example launching FCOS on AWS using a registered SSH key pair
+[source, bash]
+----
+aws ec2 run-instances <other options> --image-id <ami> --key-name my-key
+----
++
+While the AWS documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -1,0 +1,58 @@
+= Provisioning Fedora CoreOS on QEMU/libvirt
+
+This guide shows how to provision new Fedora CoreOS (FCOS) nodes using QEMU or libvirt.
+
+== Prerequisites
+
+Before provisioning a FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+== Launching with QEMU or libvirt
+
+. https://getfedora.org/coreos/download/[Download and verify] the latest image suitable for QEMU.
+
+. Uncompress the file. Assuming that the downloaded file is called `fedora-coreos-qemu.qcow2.xz`, the command would be the following:
++
+[source, bash]
+----
+unxz fedora-coreos-qemu.qcow2.xz
+----
++
+TIP: Make sure that your user has access to `/dev/kvm` (this should already be the case on modern distros), or if `/dev/kvm` is owned by the `kvm` group, adding yourself to that group with `usermod -aG kvm $USER`.
+
+. Launch the VM using `qemu-kvm` or `virt-install`. The Ignition file is passed to the VM via the `-fw_cfg` parameter, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device. For libvirt, you must pass this through the `--qemu-commandline` argument. You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM, or `qemu-img create` to first create a layered qcow2.
++
+.Example launching FCOS with QEMU (temporary storage)
+[source, bash]
+----
+qemu-kvm -m 2048 -cpu host -nographic -snapshot \
+	-drive if=virtio,file=fedora-coreos-qemu.qcow2 \
+	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign
+----
++
+.Example launching FCOS with QEMU (persistent storage)
+[source, bash]
+----
+qemu-img create -f qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
+qemu-kvm -m 2048 -cpu host -nographic \
+	-drive if=virtio,file=my-fcos-vm.qcow2 \
+	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign
+----
++
+.Example launching FCOS with virt-install
+[source, bash]
+----
+virt-install --connect qemu:///system -n fcos -r 2048 --os-variant=fedora31 --import \
+	--graphics=none --disk size=10,backing_store=/path/to/fedora-coreos-qemu.qcow2 \
+	--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=/path/to/example.ign"
+----
+
+NOTE: When using `virt-install`, you must specify absolute paths to the image and the Ignition file.
+
+TIP: If running with SELinux enabled, you may need to change the label of the Ignition file to allow access: `chcon -t svirt_home_t path/to/example.ign`
+
+Once the VM has finished booting, its IP addresses will appear on the serial console. You can then SSH into the FCOS VM as the `core` user:
+
+[source, bash]
+----
+ssh core@<ip address>
+----


### PR DESCRIPTION
Prompted by the discussion in #62.