### PR TITLE
platforms: add DigitalOcean identifier

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -31,5 +31,5 @@ Here is a list of all supported platforms and their identifier:
  * `metal`: bare metal with BIOS or UEFI boot
  * `openstack`: OpenStack (cloud platform)
  * `qemu`: QEMU (hypervisor)
- * `vmware`: VMware ESXi (hypervisor - requires hardware version 13 or later, see https://kb.vmware.com/s/article/1003746)
+ * `vmware`: VMware ESXi (hypervisor) - only on https://kb.vmware.com/s/article/1003746[hardware version] 13 or later
  * `vultr`: Vultr (cloud platform)

--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -25,6 +25,7 @@ Here is a list of all supported platforms and their identifier:
  * `aliyun`: Aliyun/Alibaba Cloud (cloud platform)
  * `aws`: Amazon Web Services (cloud platform)
  * `azure`: Microsoft Azure (cloud platform)
+ * `digitalocean`: DigitalOcean (cloud platform) - only as a https://www.digitalocean.com/docs/images/custom-images/[Custom Image]
  * `exoscale`: Exoscale (cloud platform)
  * `gcp`: Google Cloud Platform (cloud platform)
  * `ibmcloud`: IBM Cloud, VPC Generation 2 (cloud platform)


### PR DESCRIPTION
This records the `digitalocean` identifier, which is currently used
by DigitalOcean custom images but was missing from the list.