### PR TITLE
provisioning: add GCP instructions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 image="docker.io/antora/antora"
 cmd="--html-url-extension-style=indexify site.yml"

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -7,6 +7,7 @@
 ** Provisioning Machines
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
+*** xref:provisioning-gcp.adoc[Booting on GCP]
 *** xref:provisioning-vmware.adoc[Booting on VMware]
 ** System Configuration
 *** xref:producing-ign.adoc[Producing an Ignition File]

--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -1,0 +1,56 @@
+= Provisioning Fedora CoreOS on Google Cloud Platform
+
+This guide shows how to provision new Fedora CoreOS (FCOS) instances on Google Cloud Platform (GCP).
+
+== Prerequisites
+
+Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to a GCP account. The examples below use the https://cloud.google.com/sdk/gcloud[gcloud] command-line tool, which must be separately installed and configured beforehand.
+
+== Selecting an image family
+
+Fedora CoreOS is designed to be updated automatically, with different schedules per stream.
+
+FCOS images are published under the `fedora-coreos-cloud` project and further organized into images families, tracking the tip of the corresponding stream:
+
+ * `fedora-coreos-stable`
+ * `fedora-coreos-testing`
+ * `fedora-coreos-next`
+
+Before proceeding, check the details of each xref:update-streams[update stream] and pick the one most suited for your usecase.
+
+You can inspect the current state of an image family as follows:
+
+.Inspecting an image family
+[source, bash]
+----
+export STREAM='stable'
+gcloud compute images describe-from-family --project "fedora-coreos-cloud" "fedora-coreos-${STREAM}"
+----
+
+== Launching a VM instance
+
+New GCP instances can be directly created and booted from public FCOS images.
+
+If you just want SSH access and no further customization, you can skip passing any custom instance metadata. Depending on your GCP project configuration, relevant SSH public keys will be automatically added to the VM. This provides an easy way to test out FCOS without first creating an Ignition config.
+
+.Launching a new instance
+[source, bash]
+----
+export STREAM='stable'
+export VM_NAME='fcos-node01'
+gcloud compute instances create --image-project "fedora-coreos-cloud" --image-family "fedora-coreos-${STREAM}" "${VM_NAME}"
+----
+
+In order to launch a customized FCOS instance, a valid Ignition configuration has to be passed as user-data at creation time:
+
+.Launching and customizing a new instance
+[source, bash]
+----
+export STREAM='stable'
+export VM_NAME='fcos-node01'
+gcloud compute instances create --metadata-from-file "user-data=example.ign" --image-project "fedora-coreos-cloud" --image-family "fedora-coreos-${STREAM}" "${VM_NAME}"
+----
+
+NOTE: By design, https://cloud.google.com/compute/docs/startupscript[startup scripts] are not supported on FCOS. Instead, it is recommended to encode any startup logic as systemd service units in the Ignition configuration.

--- a/preview.sh
+++ b/preview.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 if [ "$(uname)" == "Darwin" ]; then
     # Running on macOS.


### PR DESCRIPTION
This adds a "Booting on GCP" guide with instructions on how to
provision FCOS instances on Google Cloud Platform.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/475