### PR TITLE
provisioning: Add getting started on Vultr tutorial

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -8,6 +8,7 @@
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
 *** xref:provisioning-vmware.adoc[Booting on VMware]
+*** xref:provisioning-vultr.adoc[Booting on Vultr]
 ** System Configuration
 *** xref:producing-ign.adoc[Producing an Ignition File]
 *** xref:fcct-config.adoc[FCCT Specification]

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -1,0 +1,37 @@
+= Provisioning Fedora CoreOS on Vultr
+
+This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Vultr.  Fedora CoreOS images are currently not published directly on Vultr, so you must download a Fedora CoreOS Vultr image and upload it to your Vultr account as a https://www.vultr.com/docs/requirements-for-uploading-an-os-iso-to-vultr[custom image].
+
+== Prerequisites
+
+Before provisioning a FCOS machine, you must have an Ignition configuration file that sets SSH authorized keys for the core user. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File]. While the Vultr documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.
+
+
+You also need to have access to a Vultr account.  The examples below use the https://github.com/vultr/vultr-cli[vultr-cli] command-line tool.
+
+== Creating a Vultr custom snapshot
+
+Fedora CoreOS is designed to be updated automatically, with different schedules per stream.
+
+. Once you have picked the relevant stream, find the corresponding Vultr image on the https://getfedora.org/coreos/download?tab=cloud_operators[download page] and copy the URL of the Download link.
+
+. Create the custom image:
++
+.Example uploading FCOS to a Vultr custom snapshot
+[source, bash]
+----
+export VULTR_API_KEY=<token>
+vultr-cli snapshot create-url -u <download-url>
+----
+
+=== Launching an instance
+
+Create a FCOS Vultr instance using the snapshot id. This example creates a 1 vCPU, 1GB RAM instance in NYC. Use `vultr-cli regions list` and `vultr plans list` for other options.
+
+[source, bash]
+----
+vultr-cli server create --snapshot <snapshot-id> --region 1 --plan 201 --userdata "$(cat example.ign)"
+----
+
+NOTE: Vultr firewall rules must be adjusted if you wish to ssh to the instance.
+


### PR DESCRIPTION
* Add Provisioning Fedora CoreOS on Vultr docs that shows uploading a snapshot image and creating an instance using the `vultr-cli`
* Ignition config must include SSH authorized key setup

Related: https://github.com/coreos/fedora-coreos-tracker/issues/355