### PR TITLE
pages: emergency-shell

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -22,5 +22,6 @@
 ** Troubleshooting
 *** xref:manual-rollbacks.adoc[Manual Rollbacks]
 *** xref:access-recovery.adoc[Access Recovery]
+*** xref:emergency-shell.adoc[Emergency Shell Access]
 * Reference pages
  ** xref:platforms.adoc[Platforms]

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -1,6 +1,6 @@
 = Access the emergency shell on boot.
 
-If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console). This usually only happens during first-boot provisioning..
+If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console). This usually only happens during first-boot provisioning.
 
 To access the emergency shell when not using a serial console, you should intercept the GRUB menu and edit the entry to drop all 'console' parameters from the kernel line that you don't need, then press Ctrl+X to resume booting.
 

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -1,0 +1,5 @@
+= Access the emergency shell on boot.
+
+If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console).
+
+To access the emergency shell when using VGA intercept the GRUB menu and edit the entry to append 'console=tty0' to the kernel argument list, then press Ctrl-X to resume booting.

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -1,7 +1,14 @@
-= Access the emergency shell on boot.
+= Access the emergency shell
 
-If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console). This usually only happens during first-boot provisioning.
 
-To access the emergency shell when not using a serial console, you should intercept the GRUB menu and edit the entry to drop all 'console' parameters from the kernel line that you don't need, then press Ctrl+X to resume booting.
+Sometimes you may want to access the emergency shell. For instance, to debug first boot provisioning errors.
 
-For VGA, you would keep 'console=tty0'
+To access the emergency shell intercept the GRUB menu, edit the entry and drop all `console` parameters from the kernel line except for the one you need and press Ctrl+X to resume booting.
+
+[NOTE]
+====
+By default these console parameters are provided:
+
+ - `console=ttyS0,115200n8` for serial consoles.
+ - `console=tty0` for VGA.
+====

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -1,5 +1,7 @@
 = Access the emergency shell on boot.
 
-If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console).
+If there is an error while booting Fedora CoreOS and emergency.target is reached a shell prompt will open by default on ttyS0 (i.e. serial console). This usually only happens during first-boot provisioning..
 
-To access the emergency shell when using VGA intercept the GRUB menu and edit the entry to append 'console=tty0' to the kernel argument list, then press Ctrl-X to resume booting.
+To access the emergency shell when not using a serial console, you should intercept the GRUB menu and edit the entry to drop all 'console' parameters from the kernel line that you don't need, then press Ctrl+X to resume booting.
+
+For VGA, you would keep 'console=tty0'


### PR DESCRIPTION
Adds documentation to describe how to access the emergency shell with tty0.

Resolves (by documentating) https://github.com/coreos/fedora-coreos-tracker/issues/453