### PR TITLE
Document SSH key and password authentication

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -16,6 +16,7 @@
 *** xref:static-ip-config.adoc[Configuring a Static IP Address]
 *** xref:sysctl.adoc[Kernel Tuning]
 *** xref:running-containers.adoc[Running Containers]
+*** xref:authentication.adoc[Configuring Authentication]
 ** OS updates
 *** xref:update-streams.adoc[Update Streams]
 *** xref:auto-updates.adoc[Auto-Updates]

--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -1,0 +1,63 @@
+= Configuring Authentication
+
+== Using an SSH key
+
+To configure an SSH key for a local user, you can use a Fedora CoreOS Config:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
+----
+
+== Using password authentication
+
+Fedora CoreOS ships with no default passwords. You can use a Fedora CoreOS Config to set a password for a local user:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      password_hash: "$y$j9T$A0Y3wwVOKP69S.1K/zYGN.$S596l11UGH3XjN..."
+----
+
+To generate a secure password hash, use the `mkpasswd` command:
+
+[source]
+----
+$ mkpasswd --method=yescrypt
+Password: 
+$y$j9T$A0Y3wwVOKP69S.1K/zYGN.$S596l11UGH3XjN...
+----
+
+The `yescrypt` hashing method is recommended for new passwords. For more details on hashing methods, see `man 5 crypt`.
+
+The configured password will be accepted for local authentication at the console. By default, Fedora CoreOS does not allow password authentication via SSH.
+
+== Enabling SSH password authentication
+
+To enable password authentication via SSH, use the following Fedora CoreOS Config:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+storage:
+  files:
+    - path: /etc/ssh/sshd_config.d/02-enable-passwords.conf
+      mode: 0644
+      contents:
+        inline: |
+          # Fedora CoreOS disables SSH password login by default.
+          # Enable it.
+          # This file must sort before 04-disable-passwords.conf.
+          PasswordAuthentication yes
+----

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -39,7 +39,7 @@ When writing FCC files, note the following changes:
 +
 For more info, see the https://github.com/coreos/afterburn/blob/master/README.md[Afterburn readme].
 
-* By default, FCOS does not allow password logins via SSH. We recommend configuring SSH keys instead.
+* By default, FCOS does not allow password logins via SSH. We recommend xref:authentication.adoc#using-an-ssh-key[configuring SSH keys] instead. If needed, you can xref:authentication.adoc#enabling-ssh-password-authentication[enable SSH password authentication].
 * Because `usermod` is not yet fully-functional on FCOS, there is a `docker` group in the `/etc/group` file. This is a stop-gap measure to facilitate a smooth transition to FCOS. The team is working on a more functional `usermod`, at which time the `docker` group will no longer be included by default. See the https://github.com/coreos/fedora-coreos-tracker/issues/2[docker group issue].
 * There is no way to create directories below the `/` directory. Changes are restricted to `/etc` and `/var`. Refer to the documentation for the xref:ign-storage.adoc[`storage`] node of the FCC configuration for details about writing directories and files to FCOS.
 * FCCs no longer have a separate section for network configuration. Use the FCC `files` section to write a https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager key file] instead.


### PR DESCRIPTION
Hold until Fedora 32 reaches FCOS stable.

Fixes https://github.com/coreos/fedora-coreos-tracker/issues/138.