### PR TITLE
provisioning: add AWS instructions

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -5,6 +5,7 @@
 ** xref:faq.adoc[FAQ]
 ** xref:migrate-cl.adoc[Migrating from Container Linux]
 ** Provisioning Machines
+*** xref:provisioning-aws.adoc[Booting on AWS]
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
 *** xref:provisioning-gcp.adoc[Booting on GCP]

--- a/modules/ROOT/pages/getting-started-aws.adoc
+++ b/modules/ROOT/pages/getting-started-aws.adoc
@@ -1,0 +1,24 @@
+:page-partial:
+
+New AWS instances can be directly created and booted from public FCOS images. The correct AMI image ID for each region can be found in the https://getfedora.org/coreos/download/[download page].
+
+If you are only interested in exploring FCOS without further customization, you can directly use a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered SSH key-pair] for the default `core` user.
+
+In order to test out FCOS this way, simply select the relevant SSH key-pair via `--key-name` when launching the new instance:
+
+.Launching a new instance
+[source, bash]
+----
+SSH_KEY_NAME="my-key"
+aws ec2 run-instances <other options> --image-id <ami> --key-name "${SSH_KEY_NAME}"
+----
+
+In order to launch a customized FCOS instance, a valid Ignition configuration must be passed as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data] at creation time:
+
+.Launching and customizing a new instance
+[source, bash]
+----
+aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
+----
+
+NOTE: By design, cloud-init configuration and startup scripts are not supported on FCOS. Instead, it is recommended to encode any startup logic as systemd service units in the Ignition configuration.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -9,35 +9,18 @@ There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testin
 
 === Provisioning Philosophy
 
-Fedora CoreOS (FCOS) has no install-time configuration. Every FCOS system begins with a generic disk image. For each deployment mechanism (cloud VM, local VM, bare metal), configuration can be supplied at first boot. FCOS reads and applies the configuration file with https://github.com/coreos/ignition[Ignition]. For cloud deployments, Ignition gathers the configuration via the cloud’s user-data mechanism. In the case of bare metal, Ignition injects the configuration at install time.
+Fedora CoreOS (FCOS) has no install-time configuration. Every FCOS system begins with a generic disk image. For each deployment mechanism (cloud VM, local VM, bare-metal server), configuration can be supplied at first boot. FCOS reads and applies the configuration file with https://github.com/coreos/ignition[Ignition]. For cloud deployments, Ignition gathers the configuration via the cloud’s user-data mechanism. In the case of bare metal, Ignition injects the configuration at install time.
 
 NOTE: For more information on configuration, refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
 
-== Launching FCOS
+== Quickstart
 
-=== Launching on Amazon Web Services (AWS)
+=== On a cloud VM (AWS example)
 
-To launch FCOS on AWS:
+include::getting-started-aws.adoc[]
 
-. Identify the correct AMI image ID for your region from https://getfedora.org/coreos/download/[the download page]
+=== On a local hypervisor (QEMU example)
 
-. Launch the VM using `aws ec2 run-instances`. The Ignition file can be passed to the VM as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data]. You can skip this step if you just want SSH access; simply pass a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered key name] via `--key-name`. This provides an easy way to test out FCOS without first creating an Ignition configuration.
-+
-.Example launching FCOS on AWS using an Ignition configuration file
-[source, bash]
-----
-aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
-----
-+
-.Example launching FCOS on AWS using a registered SSH key pair
-[source, bash]
-----
-aws ec2 run-instances <other options> --image-id <ami> --key-name my-key
-----
-+
-While the AWS documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.
-
-=== Launching with QEMU or libvirt
 . https://getfedora.org/coreos/download/[Download and verify] the latest image suitable for QEMU.
 
 . Uncompress the file. Assuming that the downloaded file is called `fedora-coreos-qemu.qcow2.xz`, the command would be the following:
@@ -87,9 +70,9 @@ Once the VM has finished booting, its IP addresses will appear on the serial con
 ssh core@<ip address>
 ----
 
-== Installing on bare metal
+== On a bare-metal server (install to disk example)
 
-Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install Fedora CoreOS to disk. This procedure injects the specified Ignition configuration at install time.
+Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install Fedora CoreOS to disk for a bare-metal server. This procedure injects the specified Ignition configuration at install time.
 
 == Where to report bugs and ask questions
 

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -1,0 +1,13 @@
+= Provisioning Fedora CoreOS on Amazon Web Services
+
+This guide shows how to provision new Fedora CoreOS (FCOS) instances on the Amazon Web Services (AWS) cloud platform.
+
+== Prerequisites
+
+Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to an AWS account. The examples below use the https://aws.amazon.com/cli/[aws] command-line tool, which must be separately installed and configured beforehand.
+
+== Launching a VM instance
+
+include::getting-started-aws.adoc[]


### PR DESCRIPTION
This adds a "Booting on AWS" guide with instructions on how to
provision FCOS instances on AWS cloud Platform.
It also re-arranges the quickstart page to re-use the same
instructions.

Ref: https://github.com/coreos/fedora-coreos-docs/pull/63#issuecomment-614509060
Closes: https://github.com/coreos/fedora-coreos-docs/issues/79