### PR TITLE
authentication: reprioritize enable-passwords.conf

### DIFF
--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -52,12 +52,12 @@ variant: fcos
 version: 1.1.0
 storage:
   files:
-    - path: /etc/ssh/sshd_config.d/02-enable-passwords.conf
+    - path: /etc/ssh/sshd_config.d/20-enable-passwords.conf
       mode: 0644
       contents:
         inline: |
           # Fedora CoreOS disables SSH password login by default.
           # Enable it.
-          # This file must sort before 04-disable-passwords.conf.
+          # This file must sort before 40-disable-passwords.conf.
           PasswordAuthentication yes
 ----


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-config/pull/480 allows us to use more sensible numbering.  Hold until that PR reaches stable.