### PR TITLE
Document authorized_keys.d

### DIFF
--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -15,6 +15,17 @@ passwd:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
 ----
 
+=== SSH key locations
+
+sshd uses a https://github.com/coreos/ssh-key-dir[helper program] to read public keys from files in a user's `~/.ssh/authorized_keys.d` directory. Key files are read in alphabetical order, ignoring dotfiles. The standard `~/.ssh/authorized_keys` file is read afterward, in the usual way. To debug the reading of `~/.ssh/authorized_keys.d`, manually run the helper program and inspect its output:
+
+[source,bash]
+----
+/usr/libexec/ssh-key-dir
+----
+
+Ignition writes configured SSH keys to `~/.ssh/authorized_keys.d/ignition`. On platforms where SSH keys can be configured at the platform level, such as AWS, Afterburn writes those keys to `~/.ssh/authorized_keys.d/afterburn`.
+
 == Using password authentication
 
 Fedora CoreOS ships with no default passwords. You can use a Fedora CoreOS Config to set a password for a local user:

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -27,7 +27,7 @@ The following changes have been made to the installation process:
 * For time synchronization, use https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/servers/Configuring_NTP_Using_the_chrony_Suite/[`chronyd`] rather than `ntpd` or `systemd-timesyncd`.
 * Automatic updates are now coordinated by Zincati, as described in the https://github.com/coreos/zincati/blob/master/docs/usage/auto-updates.md[Zincati documentation]. The rollback mechanism (via grub) is now provided by https://github.com/coreos/rpm-ostree/blob/master/README.md[`rpm-ostree`].
 * The functionality of the reboot manager (`locksmith`) is rolled into https://github.com/coreos/zincati/blob/master/README.md[Zincati].
-* The `update-ssh-keys` tool is not provided on FCOS. To update SSH keys, edit `~/ssh/authorized_keys` directly. Note that Ignition and Afterburn place SSH keys in separate files in `~/.ssh/authorized_keys.d`.
+* The `update-ssh-keys` tool is not provided on FCOS. sshd uses a xref:authentication.adoc#ssh-key-locations[helper program] to read key files directly out of `~/.ssh/authorized_keys.d`.
 
 == Configuration changes
 


### PR DESCRIPTION
Hold until https://github.com/coreos/fedora-coreos-config/pull/498 reaches stable.