### PR TITLE
getting-started: rework QEMU and libvirt sections

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -1,15 +1,15 @@
+* xref:faq.adoc[FAQ]
 * User guides
 ** xref:getting-started.adoc[Getting Started]
 ** xref:bare-metal.adoc[Installing on Bare Metal]
-** xref:migrate-ah.adoc[Migrating from Atomic Host]
-** xref:faq.adoc[FAQ]
-** xref:migrate-cl.adoc[Migrating from Container Linux]
 ** Provisioning Machines
 *** xref:provisioning-aws.adoc[Booting on AWS]
 *** xref:provisioning-azure.adoc[Booting on Azure]
 *** xref:provisioning-digitalocean.adoc[Booting on DigitalOcean]
 *** xref:provisioning-exoscale.adoc[Booting on Exoscale]
 *** xref:provisioning-gcp.adoc[Booting on GCP]
+*** xref:provisioning-libvirt.adoc[Booting on libvirt]
+*** xref:provisioning-qemu.adoc[Booting on QEMU]
 *** xref:provisioning-vmware.adoc[Booting on VMware]
 ** System Configuration
 *** xref:producing-ign.adoc[Producing an Ignition File]
@@ -26,5 +26,8 @@
 *** xref:manual-rollbacks.adoc[Manual Rollbacks]
 *** xref:access-recovery.adoc[Access Recovery]
 *** xref:emergency-shell.adoc[Emergency Shell Access]
+* Migration notes
+** xref:migrate-ah.adoc[Migrating from Atomic Host]
+** xref:migrate-cl.adoc[Migrating from Container Linux]
 * Reference pages
- ** xref:platforms.adoc[Platforms]
+** xref:platforms.adoc[Platforms]

--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -1,0 +1,29 @@
+:page-partial:
+
+. Fetch the latest image suitable for the `qemu` platform (or https://getfedora.org/coreos/download/[download and verify] it from the web).
++
+[source, bash]
+----
+STREAM="stable"
+coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
+----
++
+
+. Launch a new machine via `virt-install`, using the Ignition file with your customizations.
++
+[source, bash]
+----
+IGNITION_CONFIG="/path/to/example.ign"
+IMAGE="/path/to/image.qcow2"
+VM_NAME="fcos-test-01"
+RAM_MB="2048"
+DISK_GB="10"
+
+virt-install --connect qemu:///system -n "${VM_NAME}" -r "${RAM_MB}" --os-variant=fedora32 \
+        --import --graphics=none --disk "size=${DISK_GB},backing_store=${IMAGE}" \
+        --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${IGNITION_CONFIG}"
+----
+
+NOTE: `virt-install` requires both the OS image and Ignition file to be specified as absolute paths.
+
+TIP: Make sure that your user has access to `/dev/kvm`. On most modern distribution, this means adding yourself to the `kvm` group.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -1,81 +1,46 @@
-:experimental:
-= Fedora CoreOS - Getting Started
+= Getting Started with Fedora CoreOS
 
 == Introduction
 
 === Update Streams
 
-There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well. For more information on streams and switching between them, see xref:update-streams.adoc[Update Streams].
+There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well.
+
+For more information on streams and switching between them, see xref:update-streams.adoc[Update Streams].
 
 === Provisioning Philosophy
 
-Fedora CoreOS (FCOS) has no install-time configuration. Every FCOS system begins with a generic disk image. For each deployment mechanism (cloud VM, local VM, bare-metal server), configuration can be supplied at first boot. FCOS reads and applies the configuration file with https://github.com/coreos/ignition[Ignition]. For cloud deployments, Ignition gathers the configuration via the cloud’s user-data mechanism. In the case of bare metal, Ignition injects the configuration at install time.
+Fedora CoreOS does not have a separate install disk. Instead, every instance starts from a generic disk image which is customized on first boot via https://github.com/coreos/ignition[Ignition].
 
-NOTE: For more information on configuration, refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
+Each platform has specific logic to retrieve and apply the first boot configuration. For cloud deployments, Ignition gathers the configuration via user-data mechanisms. In the case of bare metal, Ignition can fetch its configuration from the disk or from a remote source.
+
+For more information on configuration, refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
 
 == Quickstart
 
-=== On a cloud VM (AWS example)
+=== Booting on a cloud VM (AWS example)
 
 include::getting-started-aws.adoc[]
 
-=== On a local hypervisor (QEMU example)
+=== Booting on a local hypervisor (libvirt example)
 
-. https://getfedora.org/coreos/download/[Download and verify] the latest image suitable for QEMU.
+include::getting-started-libvirt.adoc[]
 
-. Uncompress the file. Assuming that the downloaded file is called `fedora-coreos-qemu.qcow2.xz`, the command would be the following:
-+
-[source, bash]
-----
-unxz fedora-coreos-qemu.qcow2.xz
-----
-+
-TIP: Make sure that your user has access to `/dev/kvm` (this should already be the case on modern distros), or if `/dev/kvm` is owned by the `kvm` group, adding yourself to that group with `usermod -aG kvm $USER`.
+=== Exploring the OS
 
-. Launch the VM using `qemu-kvm` or `virt-install`. The Ignition file is passed to the VM via the `-fw_cfg` parameter, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device. For libvirt, you must pass this through the `--qemu-commandline` argument. You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM, or `qemu-img create` to first create a layered qcow2. For QEMU usermode networking, the assigned IP address is not reachable from the host, so `hostfwd` is used to forward a port on `localhost` to the default SSH port on the guest machine.
-+
-.Example launching FCOS with QEMU (temporary storage)
-[source, bash]
-----
-qemu-kvm -m 2048 -cpu host -nographic -snapshot \
-	-drive if=virtio,file=fedora-coreos-qemu.qcow2 \
-	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign \
-	-nic user,model=virtio,hostfwd=tcp::2222-:22
-----
-+
-.Example launching FCOS with QEMU (persistent storage)
-[source, bash]
-----
-qemu-img create -f qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
-qemu-kvm -m 2048 -cpu host -nographic \
-	-drive if=virtio,file=my-fcos-vm.qcow2 \
-	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign \
-	-nic user,model=virtio,hostfwd=tcp::2222-:22
-----
-+
-.Example launching FCOS with virt-install
-[source, bash]
-----
-virt-install --connect qemu:///system -n fcos -r 2048 --os-variant=fedora31 --import \
-	--graphics=none --disk size=10,backing_store=/path/to/fedora-coreos-qemu.qcow2 \
-	--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=/path/to/example.ign"
-----
+Once the VM has finished booting, its IP addresses will appear on the serial console. By design, there are no hard-coded default credentials.
 
-NOTE: When using `virt-install`, you must specify absolute paths to the image and the Ignition file.
-
-TIP: If running with SELinux enabled, you may need to change the label of the Ignition file to allow access: `chcon -t svirt_home_t path/to/example.ign`
-
-Once the VM has finished booting, its IP addresses will appear on the serial console. You can then SSH into the FCOS VM as the `core` user (if using QEMU, use `localhost` and pass `-p 2222` or whichever port you've forwarded):
+If you set up an xref:authentication.adoc[SSH key] for the default `core` user, you can SSH into the VM and explore the OS:
 
 [source, bash]
 ----
 ssh core@<ip address>
 ----
 
-== On a bare-metal server (install to disk example)
+== Getting in touch
 
-Follow the xref:bare-metal.adoc[Bare Metal Installation Instructions] to install Fedora CoreOS to disk for a bare-metal server. This procedure injects the specified Ignition configuration at install time.
+Bugs can be reported to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker].
 
-== Where to report bugs and ask questions
+For live questions, feel free to reach out on the `#fedora-coreos` IRC channel on freenode.
 
-Report bugs to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker] and ask questions on the `#fedora-coreos` IRC channel on freenode, the https://discussion.fedoraproject.org/c/server/coreos/[Fedora CoreOS forum], or the https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[mailing list].
+For doubts and longer discussions related to Fedora CoreOS, a https://discussion.fedoraproject.org/c/server/coreos/[forum] and a https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[mailing list] are available.

--- a/modules/ROOT/pages/provisioning-libvirt.adoc
+++ b/modules/ROOT/pages/provisioning-libvirt.adoc
@@ -1,0 +1,15 @@
+= Provisioning Fedora CoreOS on libvirt
+
+This guide shows how to provision new Fedora CoreOS (FCOS) instances on a https://libvirt.org/[libvirt] platform, using the https://www.qemu.org/[QEMU] hypervisor.
+
+== Prerequisites
+
+Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to an host machine with `libvirt`. The examples below use the `virt-install` command-line tool, which must be separately installed beforehand.
+
+TIP: If running with SELinux enabled, make sure your OS image and Ignition file are labeled as `svirt_home_t`, for example by placing them under `~/.local/share/libvirt/images/`.
+
+== Launching a VM instance
+
+include::getting-started-libvirt.adoc[]

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -1,0 +1,66 @@
+= Provisioning Fedora CoreOS on QEMU
+
+This guide shows how to provision new Fedora CoreOS (FCOS) instances on a bare https://www.qemu.org/[QEMU] hypervisor.
+
+== Prerequisites
+
+Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to an host machine with https://www.linux-kvm.org/page/Main_Page[KVM] support. The examples below use the `qemu-kvm` command-line tool, which must be separately installed beforehand.
+
+TIP: If running with SELinux enabled, make sure your OS image and Ignition file are labeled as `svirt_home_t`, for example by placing them under `~/.local/share/libvirt/images/`.
+
+== Booting a new VM on QEMU
+
+This section shows how to boot a new VM on QEMU. On this platform, The Ignition file is passed to the VM via the `-fw_cfg` parameter, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device.
+
+You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM, or `qemu-img create` to first create a layered qcow2.
+
+=== Fetching the QCOW2 image
+
+Fetch the latest image suitable for your target stream (or https://getfedora.org/coreos/download/[download and verify] it from the web).
+
+[source, bash]
+----
+STREAM="stable"
+coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
+----
+
+=== Setting up a new VM
+
+Launch the new VM using `qemu-kvm`.
+
+In snaphost mode, all changes that are performed live after boot are discarded once the machine is powered off.
+If you need to persist your changes, it is recommended to setup a dedicated persistent disk first. 
+
+.Launching FCOS with QEMU (temporary storage)
+[source, bash]
+----
+qemu-kvm -m 2048 -cpu host -nographic -snapshot \
+	-drive if=virtio,file=fedora-coreos-qemu.qcow2 \
+	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign \
+	-nic user,model=virtio,hostfwd=tcp::2222-:22
+----
+
+.Launching FCOS with QEMU (persistent storage)
+[source, bash]
+----
+qemu-img create -f qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
+qemu-kvm -m 2048 -cpu host -nographic \
+	-drive if=virtio,file=my-fcos-vm.qcow2 \
+	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign \
+	-nic user,model=virtio,hostfwd=tcp::2222-:22
+----
+
+=== Exploring the OS
+
+With QEMU usermode networking, the assigned IP address is not reachable from the host.
+
+The examples above use `hostfwd` to selectively forward the SSH port on the guest machine to the local host (port 2222).
+
+If you set up an xref:authentication.adoc[SSH key] for the default `core` user, you can SSH into the VM via the forwarded port:
+
+[source, bash]
+----
+ssh -p 2222 core@localhost
+----


### PR DESCRIPTION
This re-arranges the QEMU and libvirt steps, introducing dedicated
provisioning pages and sharing the relevant content with the
getting-started guide.

Supersedes: https://github.com/coreos/fedora-coreos-docs/pull/63