### PR TITLE
provisioning/libvirt: Add more info to TIP about SELinux

### DIFF
--- a/modules/ROOT/pages/provisioning-libvirt.adoc
+++ b/modules/ROOT/pages/provisioning-libvirt.adoc
@@ -8,7 +8,7 @@ Before provisioning a FCOS instance, you must have an Ignition configuration fil
 
 You also need to have access to an host machine with `libvirt`. The examples below use the `virt-install` command-line tool, which must be separately installed beforehand.
 
-TIP: If running with SELinux enabled, make sure your OS image and Ignition file are labeled as `svirt_home_t`, for example by placing them under `~/.local/share/libvirt/images/`.
+TIP: If running with SELinux enabled, make sure your OS image and Ignition file are labeled as `svirt_home_t`. You can do this by placing them under `~/.local/share/libvirt/images/` or running `chcon -t svirt_home_t /path/to/file`.
 
 == Launching a VM instance
 


### PR DESCRIPTION
Also tell the user how they can change the context of the file
if they don't want to place them under ~/.local/share/libvirt/images/.