### PR TITLE
faq: add an entry for BIOS/UEFI boot modes

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -236,6 +236,6 @@ systemd:
 
 == Are Fedora CoreOS x86_64 disk images hybrid BIOS+UEFI bootable?
 
-The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI boot. They contain a hybrid BIOS/UEFI partition setup that allows them to be used for either. The exception to that is the `metal4k` 4k native image, which is targeted at disks with 4k sectors and [does not have a BIOS boot partition](https://github.com/coreos/coreos-assembler/blob/12029fea7798fa5d3535eafcf8c3d02f9a6095e4/src/cmd-buildextend-metal#L200-L202) because 4k native disks are [only supported with UEFI](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/hard-drives-and-partitions#advanced-format-drives).
+The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI boot. They contain a hybrid BIOS/UEFI partition setup that allows them to be used for either. The exception to that is the `metal4k` 4k native image, which is targeted at disks with 4k sectors and https://github.com/coreos/coreos-assembler/blob/12029fea7798fa5d3535eafcf8c3d02f9a6095e4/src/cmd-buildextend-metal#L200-L202[does not have a BIOS boot partition] because 4k native disks are https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/hard-drives-and-partitions#advanced-format-drives[only supported with UEFI].
 
 https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -236,6 +236,6 @@ systemd:
 
 == Are Fedora CoreOS x86_64 disk images hybrid BIOS+UEFI bootable?
 
-The bare metal images we provide can be used for either BIOS (legacy) boot or UEFI boot,
+The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI boot. They contain a hybrid BIOS/UEFI partition setup that allows them to be used for either. The exception to that is the `metal4k` 4k native image, which is targeted at disks with 4k sectors and [does not have a BIOS boot partition](https://github.com/coreos/coreos-assembler/blob/12029fea7798fa5d3535eafcf8c3d02f9a6095e4/src/cmd-buildextend-metal#L200-L202) because 4k native disks are [only supported with UEFI](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/hard-drives-and-partitions#advanced-format-drives).
 
 https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -234,7 +234,7 @@ systemd:
       mask: true
 ----
 
-== Are Fedora CoreOS disk images hybrid BIOS+UEFI bootable?
+== Are Fedora CoreOS x86_64 disk images hybrid BIOS+UEFI bootable?
 
 The bare metal images we provide can be used for either BIOS (legacy) boot or UEFI boot,
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -206,7 +206,7 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/creating-an-ami-ebs.html#cre
 
 No. Running containers via `docker` and `podman` at the same time can cause
 issues and unexpected behavior. We highly recommend against trying to use them
-both at the same time. 
+both at the same time.
 
 It is worth noting that in Fedora CoreOS we have `docker.service`
 disabled by default but it is easily started if anything communicates
@@ -233,3 +233,9 @@ systemd:
     - name: docker.service
       mask: true
 ----
+
+== Are Fedora CoreOS disk images hybrid BIOS+UEFI bootable?
+
+The bare metal images we provide can be used for either BIOS (legacy) boot or UEFI boot, You can boot it in either BIOS (legacy) or UEFI mode regardless of what mode the OS will use once installed.
+
+https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -236,6 +236,6 @@ systemd:
 
 == Are Fedora CoreOS disk images hybrid BIOS+UEFI bootable?
 
-The bare metal images we provide can be used for either BIOS (legacy) boot or UEFI boot, You can boot it in either BIOS (legacy) or UEFI mode regardless of what mode the OS will use once installed.
+The bare metal images we provide can be used for either BIOS (legacy) boot or UEFI boot,
 
 https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss]


### PR DESCRIPTION
According to issue: https://github.com/coreos/fedora-coreos-docs/issues/100

- A faq entry added for Hybrid boot on Metal.
- On the /bare-metal page, there's already a note stating it.
- On the /platforms page, It's already written there with `metal` as well.