### PR TITLE
pages/static-ip-config: reorganize and delete some obsolete information

### DIFF
--- a/modules/ROOT/pages/static-ip-config.adoc
+++ b/modules/ROOT/pages/static-ip-config.adoc
@@ -41,4 +41,3 @@ storage:
           dns-search=redhat.com
 ----
 NOTE: Additional parameters for NetworkManager key files can be found in the https://developer.gnome.org/NetworkManager/stable/settings-connection.html[NetworkManager documentation].
-NOTE: During the initramfs portion of the boot process, dracut will attempt to grab a DHCP address. When it times out, Ignition will take over and write the above configuration into the filesystem.

--- a/modules/ROOT/pages/static-ip-config.adoc
+++ b/modules/ROOT/pages/static-ip-config.adoc
@@ -4,7 +4,9 @@ By default, an FCOS instance will attempt to grab a DHCP address from the local 
 
 As with any custom configuration on FCOS, you can write specific files in the xref:ign-storage.adoc[`storage` node] of the Ignition file.
 
-The following snippet shows how to assign the following to enp1s0:
+The following snippet shows how to assign a static configuration to `enp1s0`:
+
+NOTE: FCOS uses https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/[predictable interface names] by https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/thread/6IPTZL57Z5NLBMPYMXNVSYAGLRFZBLIP/[default]. Please take care to use the correct interface name for your hardware.
 
 * static IP: `192.0.2.10/24`
 * gateway: `192.0.2.1`
@@ -38,6 +40,7 @@ storage:
           dns=192.168.124.1;1.1.1.1;8.8.8.8
           dns-search=redhat.com
 ----
+NOTE: Additional parameters for NetworkManager key files can be found in the https://developer.gnome.org/NetworkManager/stable/settings-connection.html[NetworkManager documentation].
 NOTE: During the initramfs portion of the boot process, dracut will attempt to grab a DHCP address. When it times out, Ignition will take over and write the above configuration into the filesystem.
 
 If the interface does not come up correctly on first boot (see https://github.com/coreos/fedora-coreos-tracker/issues/358[tracker issue 358]), you have two possible workarounds.
@@ -49,6 +52,3 @@ host via the console and issue the following commands to force the static IP to 
     nmcli connection up enp1s0
 
 . If you are not able to access the host via the console, you can reboot the host and the static IP configuration will take effect.
-
-Also, interfaces should be named based on the `predictable interface names`, if a user try to configure an interface using for intance `eth0` this change might not be taken into account.
-Additional parameters can be found in the https://developer.gnome.org/NetworkManager/stable/settings-connection.html[NetworkManager] documentation.

--- a/modules/ROOT/pages/static-ip-config.adoc
+++ b/modules/ROOT/pages/static-ip-config.adoc
@@ -42,13 +42,3 @@ storage:
 ----
 NOTE: Additional parameters for NetworkManager key files can be found in the https://developer.gnome.org/NetworkManager/stable/settings-connection.html[NetworkManager documentation].
 NOTE: During the initramfs portion of the boot process, dracut will attempt to grab a DHCP address. When it times out, Ignition will take over and write the above configuration into the filesystem.
-
-If the interface does not come up correctly on first boot (see https://github.com/coreos/fedora-coreos-tracker/issues/358[tracker issue 358]), you have two possible workarounds.
-
-. If you configured a username and password in your Ignition configuration, you can log in to the
-host via the console and issue the following commands to force the static IP to take effect:
-
-    nmcli connection down enp1s0
-    nmcli connection up enp1s0
-
-. If you are not able to access the host via the console, you can reboot the host and the static IP configuration will take effect.


### PR DESCRIPTION
```
commit 53e16684d91520302ef6d37fd64c92b7adad9ec7
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Jul 26 17:32:54 2020 -0400

    pages/static-ip-config: Remove note about initramfs network bringup
    
    We no longer bring up the network in the initramfs if it's not needed.
    See https://github.com/coreos/fedora-coreos-tracker/issues/443.

commit c88cd6dcaa56410b9d904409e5d92ab434f2d1ed
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Jul 26 17:31:42 2020 -0400

    pages/static-ip-config: remove reference to bug 358
    
    https://github.com/coreos/fedora-coreos-tracker/issues/358 is fixed now
    so we shouldn't need a whole section devoted to troubleshooting the
    issue.

commit 42ec6b469f0822436c82b66d55d7f6dca24b641a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Sun Jul 26 17:28:28 2020 -0400

    pages/static-ip-config: move around useful information
    
    Move the persistent NIC naming and the link to NetworkManager
    documentation to more appropriate places higher up in the text.
```