### PR TITLE
bare-metal: add section on PXE rootfs migration

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -47,7 +47,7 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-32.20200715.3.0-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
+    APPEND initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
 IPAPPEND 2
 ----
 
@@ -65,6 +65,6 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-32.20200715.3.0-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
+    APPEND initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -46,8 +46,8 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL fedora-coreos-30.20191014.1-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
+    KERNEL fedora-coreos-32.20200715.3.0-live-kernel-x86_64
+    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
 IPAPPEND 2
 ----
 
@@ -64,7 +64,7 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL fedora-coreos-30.20191014.1-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
+    KERNEL fedora-coreos-32.20200715.3.0-live-kernel-x86_64
+    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -47,7 +47,7 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-30.20191014.1-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img console=tty0 console=ttyS0 coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
+    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://192.168.1.101:8000/config.ign
 IPAPPEND 2
 ----
 
@@ -65,6 +65,6 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-30.20191014.1-live-kernel-x86_64
-    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img console=tty0 console=ttyS0 ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
+    APPEND ip=dhcp rd.neednet=1 initrd=fedora-coreos-30.20191014.1-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -68,3 +68,22 @@ LABEL pxeboot
     APPEND initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----
+
+== PXE rootfs image
+
+NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image.  Beginning August 11, a third `rootfs` image will be added.  During an initial migration period, the `rootfs` image will be optional, and Fedora CoreOS will display a warning on login if the system was booted without it.  After the migration period, the `rootfs` image will be mandatory and the live PXE system will not boot without it.
+
+The migration timeline is:
+
+- August 11: `rootfs` image available in `next`, `testing`, and `stable` streams
+- August 25: `rootfs` image required in `next` stream
+- September 22: `rootfs` image required in `testing` stream
+- October 6: `rootfs` image required in `stable` stream
+
+To boot with the `rootfs` artifact, make one of the following changes to your PXE config:
+
+- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration.  In PXELINUX, put both file paths in the `initrd` directive, separated by commas, or specify two `initrd=` parameters in your `append` line.
+- Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd.
+- Specify only the `initramfs` file as the initrd, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument.
+
+For more information on this change, see the https://github.com/coreos/fedora-coreos-tracker/issues/390[tracker issue].


### PR DESCRIPTION
Don't update the PXE instructions yet, since we're not yet producing `rootfs` images.

Also simplify PXE kargs.

For https://github.com/coreos/fedora-coreos-tracker/issues/390.