### PR TITLE
provisioning: add instructions for live-PXE via iPXE

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -12,6 +12,8 @@
 *** xref:provisioning-qemu.adoc[Booting on QEMU]
 *** xref:provisioning-vmware.adoc[Booting on VMware]
 *** xref:provisioning-vultr.adoc[Booting on Vultr]
+** Provisioning Transient Systems
+*** xref:live-booting-ipxe.adoc[Live-booting via iPXE]
 ** System Configuration
 *** xref:producing-ign.adoc[Producing an Ignition File]
 *** xref:fcct-config.adoc[FCCT Specification]

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -69,21 +69,6 @@ LABEL pxeboot
 IPAPPEND 2
 ----
 
-== PXE rootfs image
+== PXE images
 
-NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image.  Beginning August 11, a third `rootfs` image will be added.  During an initial migration period, the `rootfs` image will be optional, and Fedora CoreOS will display a warning on login if the system was booted without it.  After the migration period, the `rootfs` image will be mandatory and the live PXE system will not boot without it.
-
-The migration timeline is:
-
-- August 11: `rootfs` image available in `next`, `testing`, and `stable` streams
-- August 25: `rootfs` image required in `next` stream
-- September 22: `rootfs` image required in `testing` stream
-- October 6: `rootfs` image required in `stable` stream
-
-To boot with the `rootfs` artifact, make one of the following changes to your PXE config:
-
-- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration.  In PXELINUX, put both file paths in the `initrd` directive, separated by commas, or specify two `initrd=` parameters in your `append` line.
-- Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd.
-- Specify only the `initramfs` file as the initrd, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument.
-
-For more information on this change, see the https://github.com/coreos/fedora-coreos-tracker/issues/390[tracker issue].
+include::pxe-artifacts.adoc[]

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -1,0 +1,42 @@
+= Booting live Fedora CoreOS via iPXE
+
+This guide shows how to boot a transient Fedora CoreOS (FCOS) system via iPXE. By default this will run FCOS in a stateless way, completely out of RAM. Separately, FCOS can also be installed to disk.
+
+== Prerequisite
+
+Before booting FCOS, you must have an Ignition configuration file and host it somewhere (e.g. on a reachable web server). If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+NOTE: The live system requires at least 3 GiB of RAM.
+
+== PXE images
+
+include::pxe-artifacts.adoc[]
+
+== Setting up the Boot Script
+
+An iPXE-capable machine needs to be provided with a relevant Boot Script to fetch and load FCOS artifacts.
+
+The example below shows how to load those directly from Fedora infrastructure. For performance and reliability reasons it is recommended to mirror them on the local infrastructure, and then tweak the `BASEURL` as needed.
+
+[source]
+----
+#!ipxe
+
+set STREAM stable
+set VERSION 32.20200726.3.0
+set CONFIGURL https://example.com/config.ign
+
+set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds/${VERSION}/x86_64
+
+kernel ${BASEURL}/fedora-coreos-${VERSION}-live-kernel-x86_64 ignition.firstboot ignition.platform.id=metal ignition.config.url=${CONFIGURL}
+initrd ${BASEURL}/fedora-coreos-${VERSION}-live-initramfs.x86_64.img
+initrd ${BASEURL}/fedora-coreos-${VERSION}-live-rootfs.x86_64.img
+
+boot
+----
+
+== Update process
+
+Since the traditional FCOS upgrade process requires a disk, live-PXE systems are not able to auto-update in place. For this reason, Zincati is not running there.
+
+Instead, it is reccomended that images references in the PXE configuration are regularly refreshed. Once infrastructure and configurations are updated, the live-PXE instance simply needs to be rebooted in order to start running the new FCOS version.

--- a/modules/ROOT/pages/pxe-artifacts.adoc
+++ b/modules/ROOT/pages/pxe-artifacts.adoc
@@ -1,0 +1,18 @@
+:page-partial:
+
+NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image.  Beginning August 11, a third `rootfs` image will be added.  During an initial migration period, the `rootfs` image will be optional, and Fedora CoreOS will display a warning on login if the system was booted without it.  After the migration period, the `rootfs` image will be mandatory and the live PXE system will not boot without it.
+
+The migration timeline is:
+
+- August 11: `rootfs` image available in `next`, `testing`, and `stable` streams
+- August 25: `rootfs` image required in `next` stream
+- September 22: `rootfs` image required in `testing` stream
+- October 6: `rootfs` image required in `stable` stream
+
+To boot with the `rootfs` artifact, make one of the following changes to your PXE config:
+
+- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments.
+- Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd.
+- Specify only the `initramfs` file as the initrd, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument.
+
+For more information on this change, see the https://github.com/coreos/fedora-coreos-tracker/issues/390[tracker issue].


### PR DESCRIPTION
This adds a new guide showing how to provision a transient FCOS
instance by live-PXE booting it via iPXE.

Ref: https://github.com/coreos/fedora-coreos-docs/issues/117