### PR TITLE
FAQ: Replace 'Discuss' with 'Discuss on discussion.fedoraproject.org'

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -238,7 +238,7 @@ systemd:
 
 The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI boot. They contain a hybrid BIOS/UEFI partition setup that allows them to be used for either. The exception to that is the `metal4k` 4k native image, which is targeted at disks with 4k sectors and https://github.com/coreos/coreos-assembler/blob/12029fea7798fa5d3535eafcf8c3d02f9a6095e4/src/cmd-buildextend-metal#L200-L202[does not have a BIOS boot partition] because 4k native disks are https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/hard-drives-and-partitions#advanced-format-drives[only supported with UEFI].
 
-https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss]
+https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss on discussion.fedoraproject.org]
 
 == What's the difference between Ignition and FCCT configurations?
 


### PR DESCRIPTION
Missed this one during the first pass.

Fixes: 79397d3 FAQ: Replace 'discuss' with 'Discuss on discussion.fedoraproject.org' (#114)