### PR TITLE
Bump all FCCT sample configs to 1.1.0

### DIFF
--- a/modules/ROOT/pages/auto-updates.adoc
+++ b/modules/ROOT/pages/auto-updates.adoc
@@ -20,7 +20,7 @@ This can be done during provisioning by using the xref:fcct-config.adoc[FCCT] co
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   files:
     - path: /etc/zincati/config.d/51-rollout-wariness.toml
@@ -49,7 +49,7 @@ The xref:fcct-config.adoc[FCCT] snippet below shows how to define two maintenanc
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   files:
     - path: /etc/zincati/config.d/55-updates-strategy.toml

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -227,7 +227,7 @@ masking the `docker.service` systemd unit.
 [source, yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: docker.service

--- a/modules/ROOT/pages/fcct-config.adoc
+++ b/modules/ROOT/pages/fcct-config.adoc
@@ -34,13 +34,13 @@ TIP: YAML files must have consistent indentation. See the https://yaml.org/spec/
 
 == FCC file metadata (`variant` and `version`)
 
-The first two lines of an FCC file define `fcos` as the operating system and the semantic version of the document specification (`1.0.0`). Both lines are required.
+The first two lines of an FCC file define `fcos` as the operating system and the semantic version of the document specification (e.g. `1.1.0`). Both lines are required.
 
 .Example of the FCC file metadata
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 ----
 
 include::ign-config-metadata.adoc[leveloffset=1]

--- a/modules/ROOT/pages/ign-config-metadata.adoc
+++ b/modules/ROOT/pages/ign-config-metadata.adoc
@@ -38,7 +38,7 @@ The following examples show how to retrieve an Ignition file from a remote sourc
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 ignition:
   config:
     replace:
@@ -51,7 +51,7 @@ ignition:
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 ignition:
   config:
     replace:

--- a/modules/ROOT/pages/ign-storage.adoc
+++ b/modules/ROOT/pages/ign-storage.adoc
@@ -34,7 +34,7 @@ Every entry under the `disks` node must correspond to a unique device. For each 
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   disks:
     -
@@ -87,7 +87,7 @@ Entries under the `filesystems` node list the file systems to be created and mou
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   disks:
   # This defines two partitions, each on its own disk. The disks are
@@ -129,7 +129,7 @@ storage:
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   disks:
   -
@@ -239,7 +239,7 @@ The contents of `links` is as follows. Unless specified as optional, all nodes a
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   # This creates a directory.  Its mode is set to 0755 by default, that
   # is, readable and executable by all, and writable by the owner.

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -31,7 +31,7 @@ The SSH public key will be provisioned to the FCOS machine (via Ignition). The S
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/running-containers.adoc
+++ b/modules/ROOT/pages/running-containers.adoc
@@ -10,7 +10,7 @@ The following FCOS Configuration (FCC) snippet configures the systemd hello.serv
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: hello.service
@@ -40,7 +40,7 @@ etcd is not shipped as part of Fedora CoreOS. To use it, run it as a container, 
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: etcd-member.service

--- a/modules/ROOT/pages/static-ip-config.adoc
+++ b/modules/ROOT/pages/static-ip-config.adoc
@@ -17,7 +17,7 @@ NOTE: FCOS uses https://www.freedesktop.org/wiki/Software/systemd/PredictableNet
 [source, yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/enp1s0.nmconnection

--- a/modules/ROOT/pages/sysctl.adoc
+++ b/modules/ROOT/pages/sysctl.adoc
@@ -11,7 +11,7 @@ As an example, the https://github.com/coreos/fcct[FCCT] snippet below shows how 
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 storage:
   files:
     - path: /etc/sysctl.d/90-sysrq.conf

--- a/modules/ROOT/pages/tutorial-advanced-provisioning.adoc
+++ b/modules/ROOT/pages/tutorial-advanced-provisioning.adoc
@@ -21,7 +21,7 @@ We'll create this config in a file called `./fcct-advanced.yaml`
 ----
 [host]$ cat fcct-advanced.yaml
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/tutorial-basic-provisioning-and-customization.adoc
+++ b/modules/ROOT/pages/tutorial-basic-provisioning-and-customization.adoc
@@ -67,7 +67,7 @@ We can create a simple FCCT config file named `fcct-simple.yaml` now as:
 [source,yaml]
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: serial-getty@tty0.service

--- a/modules/ROOT/pages/tutorial-intermediate-provisioning.adoc
+++ b/modules/ROOT/pages/tutorial-intermediate-provisioning.adoc
@@ -56,7 +56,7 @@ We'll store these contents in `fcct-intermediate.yaml`.
 
 ----
 variant: fcos
-version: 1.0.0
+version: 1.1.0
 systemd:
   units:
     - name: serial-getty@ttyeS0.service


### PR DESCRIPTION
It's fully backwards compatible with 1.0.0, and we want to be nice to
people who try to start from a baked config and then add 1.1.0-specific
things.