### PR TITLE
Fix systemd tty service name typo

### DIFF
--- a/modules/ROOT/pages/tutorial-basic-provisioning-and-customization.adoc
+++ b/modules/ROOT/pages/tutorial-basic-provisioning-and-customization.adoc
@@ -70,7 +70,7 @@ variant: fcos
 version: 1.1.0
 systemd:
   units:
-    - name: serial-getty@tty0.service
+    - name: serial-getty@ttyS0.service
       dropins:
       - name: autologin-core.conf
         contents: |


### PR DESCRIPTION
Fix typo in example FCCT config such that the resulting ign produced by fcct works as intended