### PR TITLE
README.md: mention podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This repo includes scripts to build and preview the contents of this repository.
 
 **NOTE**: Please note that if you reference pages from other repositories, such links will be broken in this local preview as it only builds this repository. If you want to rebuild the whole Fedora Docs site, please see [the Fedora Docs build repository](https://pagure.io/fedora-docs/docs-fp-o/) for instructions.
 
-Both scripts use docker, so please make sure you have it installed on your system.
+Please make sure you have `podman` or `docker` installed on your system.
 
 To build and preview the site, run:
 


### PR DESCRIPTION
The script actually tries podman first, then fallback to docker. Also,
the `preview.sh` script doesn't need a container runtime on Linux, so
reword.