### PR TITLE
Document installing from the container and the metal image itself

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -1,10 +1,11 @@
 :experimental:
 = Installing CoreOS on Bare Metal
 
-This guide provides instructions to install Fedora CoreOS to bare metal. Two options are available:
+This guide provides instructions to install Fedora CoreOS to bare metal. Three options are available:
 
 * Installing from live ISO
 * Installing from PXE
+* Installing from the container
 
 == Prerequisite
 
@@ -52,6 +53,20 @@ IPAPPEND 2
 ----
 
 For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`.
+
+== Installing from the container
+
+You can use the `coreos-installer` https://quay.io/repository/coreos/coreos-installer[container] from an existing system to install to an attached block device. For example (substitute `docker` for `podman` if needed):
+
+[source, bash]
+----
+sudo podman run --pull=always --privileged --rm \
+    -v /dev:/dev -v /run/udev:/run/udev -v ${PWD}:/data \
+    quay.io/coreos/coreos-installer:release \
+    install /dev/vdb -i /data/config.ign
+----
+
+In this example, `coreos-installer` will download the latest stable FCOS metal image and install it onto `/dev/vdb`. It will then inject the Ignition file `config.ign` in the current directory into the image.  Use `--help` to see all the available options.
 
 == Live PXE
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -68,6 +68,20 @@ sudo podman run --pull=always --privileged --rm \
 
 In this example, `coreos-installer` will download the latest stable FCOS metal image and install it onto `/dev/vdb`. It will then inject the Ignition file `config.ign` in the current directory into the image.  Use `--help` to see all the available options.
 
+== Downloading and mirroring the metal image
+
+Sometimes, it's necessary to download the metal image ahead of time and then have it passed locally to `coreos-installer` for installation. You can download the metal image directly from the https://getfedora.org/en/coreos/download?tab=metal_virtualized[FCOS download page], or you can use `coreos-installer download`.
+
+TIP: When installing via the live ISO or PXE, there is no need to download the metal image. It is already part of those environments.
+
+There are two metal images: one for 512b-sector disks (labeled "Raw" on the download page), and one for 4k-sector native disks (labeled "Raw (4K Native)"). Unless you know to be targeting a 4k native disk, use the 512b one, which is the most common. See https://en.wikipedia.org/wiki/Advanced_Format#4K_native[this page] for more information.
+
+To download the 4kn native metal image with `coreos-installer download`, use the `--format 4k.raw.xz` switch.
+
+NOTE: The metal image uses a hybrid partition layout which supports both BIOS and UEFI booting.
+
+When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-install --image-file <PATH>`.
+
 == Live PXE
 
 In this model, rather than performing a "persistent" installation to disk, you can run directly from RAM.  This is useful in e.g. "diskless" scenarios.

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -19,11 +19,11 @@ To install FCOS onto bare metal using the live ISO, follow these steps:
 NOTE: The live system requires at least 3 GiB of RAM. You can boot it in either legacy BIOS or UEFI mode, regardless of what mode the OS will use once installed.
 +
 . Burn the ISO to disk and boot it on the target system. The ISO is capable of bringing up a fully functioning FCOS system purely from memory (i.e. without using any disk storage). Once booted, you will have access to a bash command prompt.
-. You can now fetch your Ignition config and run `coreos-installer`:
+. You can now run `coreos-installer`:
 [source, bash]
 ----
-curl -LO https://example.com/example.ign
-sudo coreos-installer install /dev/sda --ignition-file example.ign
+sudo coreos-installer install /dev/sda \
+    --ignition-url https://example.com/example.ign
 ----
 
 Once the installation is complete, you can simply `sudo reboot`. After rebooting, the first boot process begins. It is at this time that Ignition ingests the configuration file and provisions the system as specified.


### PR DESCRIPTION
```
commit 94e659e5e0d4947cb593403209bffacce343730e
Date:   Fri Aug 7 11:27:11 2020 -0400

    bare-metal: use `--ignition-url`

    No need to separately `curl` the Ignition config now.

commit fdb5a88db254bb914ea8e2a3e249cdc8ad17511d
Date:   Fri Aug 7 11:27:50 2020 -0400

    bare-metal: document installing from the container

commit f8521b71004774b34ca5045a2f764c893d670ff5
Date:   Fri Aug 7 11:28:19 2020 -0400

    bare-metal: document the metal image

    E.g. downloading it directly for mirroring or for offline environments
    where they don't to/can't use our live environments for some reason.
    Also add docs about 512b vs 4k native disks and a note about dual
    UEFI/BIOS.

    Fixes: #78
```
