### PR TITLE
Add FCC for setting a custom hostname

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -22,6 +22,7 @@
 *** xref:sysctl.adoc[Kernel Tuning]
 *** xref:running-containers.adoc[Running Containers]
 *** xref:authentication.adoc[Configuring Authentication]
+*** xref:hostname.adoc[Setting a Hostname]
 ** OS updates
 *** xref:update-streams.adoc[Update Streams]
 *** xref:auto-updates.adoc[Auto-Updates]

--- a/modules/ROOT/pages/hostname.adoc
+++ b/modules/ROOT/pages/hostname.adoc
@@ -1,0 +1,23 @@
+:experimental:
+= Setting a Hostname
+
+To set a custom hostname for your system, use the following FCC to write to `/etc/hostname`:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - $pubkey
+storage:
+  files:
+    - path: /etc/hostname
+      mode: 0644
+      contents:
+        inline: myhostname
+----
+
+Once booted, you can also verify that the desired hostname has been set using `hostnamectl`.


### PR DESCRIPTION
This duplicates the tutorial. Though it's nice to have it stand-alone
too I think once we move it to a page dedicated to networking (#107).

Fixes: #129