### PR TITLE
pxe: add kargs for cgroups v1

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -94,7 +94,7 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-32.20200715.3.0-live-kernel-x86_64
-    APPEND initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
+    APPEND initrd=fedora-coreos-32.20200715.3.0-live-initramfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign systemd.unified_cgroup_hierarchy=0
 IPAPPEND 2
 ----
 

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -28,7 +28,7 @@ set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds/${VERSION}/x86_64
 
-kernel ${BASEURL}/fedora-coreos-${VERSION}-live-kernel-x86_64 ignition.firstboot ignition.platform.id=metal ignition.config.url=${CONFIGURL}
+kernel ${BASEURL}/fedora-coreos-${VERSION}-live-kernel-x86_64 ignition.firstboot ignition.platform.id=metal ignition.config.url=${CONFIGURL} systemd.unified_cgroup_hierarchy=0
 initrd ${BASEURL}/fedora-coreos-${VERSION}-live-initramfs.x86_64.img
 initrd ${BASEURL}/fedora-coreos-${VERSION}-live-rootfs.x86_64.img
 


### PR DESCRIPTION
This aligns kargs parameters on live-PXE guides to ensure that
such systems are booted with the default cgroups v1 mode.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/598