### PR TITLE
faq: update locksmith/CLUO status

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -179,10 +179,15 @@ https://discussion.fedoraproject.org/t/launch-faq-how-do-i-run-custom-applicatio
 
 == How do I coordinate cluster-wide OS updates? Is locksmith or the Container Linux Update Operator available for Fedora CoreOS?
 
-We have ported the Container Linux Update Operator to use rpm-ostree in
-the upstream repo. If you are using Fedora CoreOS outside of a
-Kubernetes cluster, you will be able to use upcoming tools to coordinate
-updates and reboots.
+The `etcd-lock` feature from https://github.com/coreos/locksmith[locksmith] has
+been directly ported to Zincati, as a https://coreos.github.io/zincati/usage/updates-strategy/#lock-based-strategy[lock-based updates strategy].
+It has also been augmented to support multiple backends, not being anymore
+constrained to etcd2 only.
+
+The capabilities of https://github.com/coreos/container-linux-update-operator[Container Linux Update Operator (CLUO)]
+have been embedded into the https://github.com/openshift/machine-config-operator[Machine Config Operator (MCO)],
+which is a core component of OKD.
+The MCO additionally covers reconciliation of machine configuration changes.
 
 https://discussion.fedoraproject.org/t/launch-faq-how-do-i-coordinate-cluster-wide-os-updates-is-locksmith-or-the-container-linux-update-operator-available-for-fedora-coreos/56[Discuss on discussion.fedoraproject.org]
 


### PR DESCRIPTION
This updates the FAQ entry for locksmith/CLUO, pointing to their
morphing into Zincati and MCO.

Ref: https://discussion.fedoraproject.org/t/cluo-for-fedora-coreos/22429