### PR TITLE
bare-metal: revert section-title change

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -98,6 +98,6 @@ LABEL pxeboot
 IPAPPEND 2
 ----
 
-== PXE images
+== PXE rootfs image
 
 include::pxe-artifacts.adoc[]


### PR DESCRIPTION
This reverts a change in a section heading, which broke an incoming
link from https://github.com/coreos/fedora-coreos-config/pull/528.