### PR TITLE
nav: add section for upstream projects

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -34,12 +34,14 @@
 * Migration notes
 ** xref:migrate-ah.adoc[Migrating from Atomic Host]
 ** xref:migrate-cl.adoc[Migrating from Container Linux]
-* Reference pages
-** xref:platforms.adoc[Platforms]
-** xref:fcos-projects.adoc[Projects Using Fedora CoreOS]
 * xref:tutorials.adoc[Tutorials]
 ** xref:tutorial-setup.adoc[Initial setup]
 ** xref:tutorial-autologin.adoc[Enabling autologin and custom hostname]
 ** xref:tutorial-services.adoc[Starting a service on first boot]
 ** xref:tutorial-containers.adoc[SSH access and starting containers]
 ** xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]
+* Reference pages
+** xref:platforms.adoc[Platforms]
+** xref:fcos-projects.adoc[Projects Using Fedora CoreOS]
+* Projects
+** https://coreos.github.io/zincati/[Zincati]


### PR DESCRIPTION
This adds a new nav-section for upstream projects. It also adds an
initial entry, linking to Zincati upstream docs.