### PR TITLE
remove quotes from disk size

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -17,7 +17,7 @@ IGNITION_CONFIG="/path/to/example.ign"
 IMAGE="/path/to/image.qcow2"
 VM_NAME="fcos-test-01"
 RAM_MB="2048"
-DISK_GB="10"
+DISK_GB=10
 
 virt-install --connect qemu:///system -n "${VM_NAME}" -r "${RAM_MB}" --os-variant=fedora32 \
         --import --graphics=none --disk "size=${DISK_GB},backing_store=${IMAGE}" \

--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -19,9 +19,11 @@ VM_NAME="fcos-test-01"
 RAM_MB="2048"
 DISK_GB=10
 
-virt-install --connect qemu:///system -n "${VM_NAME}" -r "${RAM_MB}" --os-variant=fedora32 \
-        --import --graphics=none --disk "size=${DISK_GB},backing_store=${IMAGE}" \
-        --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${IGNITION_CONFIG}"
+virt-install --connect qemu:///system --name fcos-test-01 --memory 2048 --os-variant=fedora32 \
+        --import --graphics=none vcpus=2,maxcpus=4 --disk
+        size=10,format=qcow2,backing_store=/path/to/image.qcow2 \
+        --qemu-commandline="-fw_cfg
+        name=opt/com.coreos/config,file=/path/to/example.ign
 ----
 
 NOTE: `virt-install` requires both the OS image and Ignition file to be specified as absolute paths.

--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -20,10 +20,10 @@ RAM_MB="2048"
 DISK_GB=10
 
 virt-install --connect qemu:///system --name fcos-test-01 --memory 2048 --os-variant=fedora32 \
-        --import --graphics=none vcpus=2,maxcpus=4 --disk
-        size=10,format=qcow2,backing_store=/path/to/image.qcow2 \
-        --qemu-commandline="-fw_cfg
-        name=opt/com.coreos/config,file=/path/to/example.ign
+        --import --graphics=none vcpus=2,maxcpus=4 --disk size=10 \
+        format=qcow2,backing_store=/path/to/image.qcow2 \
+        --qemu-commandline="-fw_cg
+        name=opt/com.coreos/config,file=/path/to/example.ign"
 ----
 
 NOTE: `virt-install` requires both the OS image and Ignition file to be specified as absolute paths.


### PR DESCRIPTION
- Setting the disk size between quotes output an error. Remove the quotes around the integer.
- Don't over complicate with environment variables
- `-r ` for ram is depreciated. Use `---memory` instead
- Good practice is to set `--vcpus `explicitly 
