### PR TITLE
Add dedicated page to configuring storage

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 *** xref:producing-ign.adoc[Producing an Ignition File]
 *** xref:fcct-config.adoc[FCCT Specification]
 *** xref:using-fcct.adoc[Using FCCT]
+*** xref:storage.adoc[Configuring Storage]
 *** xref:static-ip-config.adoc[Configuring a Static IP Address]
 *** xref:sysctl.adoc[Kernel Tuning]
 *** xref:running-containers.adoc[Running Containers]

--- a/modules/ROOT/pages/ign-storage.adoc
+++ b/modules/ROOT/pages/ign-storage.adoc
@@ -1,6 +1,6 @@
 = Storage specification
 
-This section describes the FCOS Configuration (FCC) YAML format for defining the desired state of storage associated with a FCOS instance.
+This section describes the FCOS Configuration (FCC) YAML format for defining the desired state of storage associated with a FCOS instance. See also xref:storage.adoc[Configuring Storage] which contains examples for customizing the default storage layout.
 
 The `storage` block contains a list of objects, which can be of the following type:
 
@@ -123,48 +123,6 @@ storage:
       device: /dev/md/publicdata
       format: ext4
       label: PUB
-----
-
-.Example for adding a /var partition to the primary disk
-[source,yaml]
-----
-variant: fcos
-version: 1.1.0
-storage:
-  disks:
-  -
-    # The name of the primary block device. In virtio-based setups, this is
-    # likely `/dev/vda`. Elsewhere, it's likely `/dev/sda`.
-    device: /dev/vda
-    # We do not want to wipe the partition table since this is the primary
-    # device.
-    wipe_table: false
-    partitions:
-    - size_mib: 0
-      start_mib: 0
-      # We assign a descriptive label to the partition. This is important
-      # for referring to it in a device-agnostic way in other parts of the
-      # configuration.
-      label: var
-  filesystems:
-    - path: /var
-      device: /dev/disk/by-partlabel/var
-      format: xfs
-systemd:
-  units:
-    -
-      # We need to create a systemd mount unit so that /var actually gets
-      # mounted on /var.
-      name: var.mount
-      enabled: true
-      contents: |
-        [Unit]
-        Before=local-fs.target
-        [Mount]
-        Where=/var
-        What=/dev/disk/by-partlabel/var
-        [Install]
-        WantedBy=local-fs.target
 ----
 
 == Files

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -1,0 +1,89 @@
+= Configuring Storage
+
+Fedora CoreOS ships with a simple default storage layout: the root partition is the last one and expands to take the full size of the disk. Apart from the boot partition, all data is stored on the root partition.
+
+Below, we provide examples of various ways you can customize this.
+
+== Setting up separate /var mounts
+
+Here's an example FCC file to set up `/var` on a separate partition on the same primary disk:
+
+.Adding a /var partition to the primary disk
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+storage:
+  disks:
+  - # The name of the primary block device. In virtio-based setups, this is
+    # likely `/dev/vda`. Elsewhere, it's likely `/dev/sda`.
+    device: /dev/vda
+    # We do not want to wipe the partition table since this is the primary
+    # device.
+    wipe_table: false
+    partitions:
+    - size_mib: 0
+      # Start at 5G so that we leave enough space for the root partition.
+      # See the important NOTE below about this.
+      start_mib: 5000
+      # We assign a descriptive label to the partition. This is important
+      # for referring to it in a device-agnostic way in other parts of the
+      # configuration.
+      label: var
+  filesystems:
+    - path: /var
+      device: /dev/disk/by-partlabel/var
+      # We can select the filesystem we'd like.
+      format: ext4
+      # Ask FCCT to generate a mount unit for us so that this filesystem gets
+      # mounted in the real root.
+      with_mount_unit: true
+----
+
+NOTE: The `start_mib` field is very important. In the future, we will make more clear how much space should be reserved for the root filesystem (see https://github.com/coreos/fedora-coreos-tracker/issues/586). For now, make sure to leave at least 5G.
+
+You can of course mount only a subset of `/var` into a separate partition. For example, to mount `/var/lib/containers`:
+
+.Adding a /var/lib/containers partition to the primary disk
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+storage:
+  disks:
+  - device: /dev/vda
+    wipe_table: false
+    partitions:
+    - size_mib: 0
+      # Start at 5G so that we leave enough space for the root partition.
+      # See the important NOTE above about this.
+      start_mib: 5000
+      label: containers
+  filesystems:
+    - path: /var/lib/containers
+      device: /dev/disk/by-partlabel/containers
+      format: xfs
+      with_mount_unit: true
+----
+
+Alternatively, you can also mount storage from a separate disk. For example, here we mount `/var/log` from a partition on `/dev/vdb`:
+
+.Adding /var/log from a secondary disk
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+storage:
+  disks:
+  - device: /dev/vdb
+    wipe_table: false
+    partitions:
+    - size_mib: 0
+      start_mib: 0
+      label: log
+  filesystems:
+    - path: /var/log
+      device: /dev/disk/by-partlabel/log
+      format: xfs
+      with_mount_unit: true
+----


### PR DESCRIPTION
Let's have a page where we list different ways one can modify the
default storage layout on FCOS. This will also include root
reprovisioning examples such as xfs → btrfs, or root on RAID1,
eventually root on LUKS, etc...

Closes: #131