### PR TITLE
Link to stream endpoint and mention it in AWS

### DIFF
--- a/modules/ROOT/pages/getting-started-aws.adoc
+++ b/modules/ROOT/pages/getting-started-aws.adoc
@@ -1,6 +1,6 @@
 :page-partial:
 
-New AWS instances can be directly created and booted from public FCOS images. The correct AMI image ID for each region can be found in the https://getfedora.org/coreos/download/[download page].
+New AWS instances can be directly created and booted from public FCOS images.  You can find the latest AMI for each region from the xref:getting-started.adoc[Update Streams], which is also visualized in the https://getfedora.org/coreos/download/[download page].
 
 If you are only interested in exploring FCOS without further customization, you can directly use a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered SSH key-pair] for the default `core` user.
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -6,6 +6,11 @@
 
 There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well.
 
+Each stream has a canonical URL representing its current state in JSON format.  For example, the URL for the stable stream is: https://builds.coreos.fedoraproject.org/streams/stable.json
+
+While Fedora CoreOS does automatic in-place updates, it is generally a good practice to start provisioning new machines from the latest images.
+The format of this JSON file is stable, and you can parse it to e.g. find the latest ISO/AMI/etc.
+
 For more information on streams and switching between them, see xref:update-streams.adoc[Update Streams].
 
 === Provisioning Philosophy


### PR DESCRIPTION
We want people provisioning new systems in an automated fashion
to script it by parsing the stream metadata.  Describe that more
including its URL in docs, and also mention it in the AWS section.