### PR TITLE
FAQ: add link to issue tracker + fedocal

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -81,6 +81,10 @@ https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[co
 * Twitter at https://twitter.com/fedora[@fedora] (all Fedora and
 other relevant news)
 
+There is a community meeting that happens every week.  See the https://apps.fedoraproject.org/calendar/CoreOS[Fedora CoreOS fedocal] for the most up-to-date information.
+
+If you think you have found a problem with Fedora CoreOS, file an issue in our https://github.com/coreos/fedora-coreos-tracker/issues[issue tracker].
+
 https://discussion.fedoraproject.org/t/launch-faq-what-are-the-communication-channels-around-fedora-coreos/46/1[Discuss on discussion.fedoraproject.org]
 
 == Technical FAQ


### PR DESCRIPTION
It was noted on the mailing list[0] that we didn't mention the issue
tracker in the FAQ or our community meeting.

[0] https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/message/EIDA6TKU4DPJ6V734F2E3MV7QOMYN7EF/