### PR TITLE
getting-started-libvirt: mention how to get coreos-installer

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -1,11 +1,15 @@
 :page-partial:
 
-. Fetch the latest image suitable for the `qemu` platform (or https://getfedora.org/coreos/download/[download and verify] it from the web).
+. Fetch the latest image suitable for the `qemu` platform using `coreos-installer` (or https://getfedora.org/coreos/download/[download and verify] it from the web). You can use `coreos-installer` https://quay.io/repository/coreos/coreos-installer[as a container], or on Fedora install it from the repos.
 +
 [source, bash]
 ----
 STREAM="stable"
+# as an installed binary:
 coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
+# or as a container:
+podman run --pull=always --rm -v $HOME/.local/share/libvirt/images/:/data -w /data \
+    quay.io/coreos/coreos-installer:release download -s "${STREAM}" -p qemu -f qcow2.xz --decompress
 ----
 +
 


### PR DESCRIPTION
This is the first mention of coreos-installer when reading from the
Getting Started guide. Let's provide more info re. where they can get
coreos-installer from.

Closes: #192