### PR TITLE
*: adjust live RAM requirements

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -21,7 +21,7 @@ podman run --privileged --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -f iso
 ----
 +
-NOTE: The live system requires at least 3 GiB of RAM. You can boot it in either legacy BIOS or UEFI mode, regardless of what mode the OS will use once installed.
+NOTE: You can boot the live ISO in either legacy BIOS or UEFI mode, regardless of what mode the OS will use once installed.
 +
 . Burn the ISO to disk and boot it on the target system. The ISO is capable of bringing up a fully functioning FCOS system purely from memory (i.e. without using any disk storage). Once booted, you will have access to a bash command prompt.
 . You can now run `coreos-installer`:
@@ -46,7 +46,7 @@ podman run --privileged --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -f pxe
 ----
 +
-NOTE: You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
+NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 3 GiB otherwise. You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
 +
 . Follow this example `pxelinux.cfg` for booting the installer images with PXELINUX:
 +

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -6,7 +6,7 @@ This guide shows how to boot a transient Fedora CoreOS (FCOS) system via iPXE. B
 
 Before booting FCOS, you must have an Ignition configuration file and host it somewhere (e.g. on a reachable web server). If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
-NOTE: The live system requires at least 3 GiB of RAM.
+NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 3 GiB otherwise.
 
 == PXE images
 


### PR DESCRIPTION
Require 2 GiB of RAM for live PXE.  Live ISO no longer has any unusual RAM requirements, so drop the caveat entirely.

Per https://github.com/coreos/fedora-coreos-tracker/issues/407#issuecomment-680258844 and https://github.com/coreos/fedora-coreos-tracker/issues/407#issuecomment-709463014.