### PR TITLE
Fix external link

### DIFF
--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -1,7 +1,7 @@
 = How to Customize a NIC Name
 
 == Using a systemd Link File
-You can create a systemd xref:https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
+You can create a systemd link:https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
 
 For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:fcct-config.adoc[FCCT] configuration snippet shown below:
 

--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -1,7 +1,7 @@
 = How to Customize a NIC Name
 
 == Using a systemd Link File
-You can create a systemd link:https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
+You can create a systemd https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
 
 For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:fcct-config.adoc[FCCT] configuration snippet shown below:
 


### PR DESCRIPTION
This link wrongly linked to `./` and thus was not considered an absolute path.
This change should fix that.

Note that in https://docs.fedoraproject.org/en-US/fedora-docs/asciidoc-fedora/markup/#snippets I could not find any information for external links, so I choose to just use the "default" AsciiDoc syntax.

---

It would be nice if you could tag this PR with `hacktoberfest-accepted` or so:

[Hacktoberfest 2020](https://hacktoberfest.digitalocean.com/) – a project promoting open source contributions – is running this month.

As [they have changed the rules recenty](https://dev.to/devteam/hacktoberfest-etiquette-for-contributors-ec6) you do now have to tag your repository/repositories (=set a GitHub topic) if you want to have participated in this with the tag `hacktoberfest`.
AFAIK you can alternatively also [tag single PRs with `hacktoberfest-accepted`](https://hacktoberfest.digitalocean.com/details#details) to mark them as a valid PR. (Otherwise all merged or positively reviewed PRs count.)