### PR TITLE
provisioning/vmware: update example and guestinfo details

### DIFF
--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -83,7 +83,9 @@ For this reason, on first-boot FCOS instances try to perform network autoconfigu
 If your VMware setup employs static network configuration instead, you can override this automatic DHCP setup with your own custom configuration.
 Custom networking command-line `ip=` parameter can be configured via guestinfo properties as shown below, before booting a VM for the first time.
 
-The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry. Note that the network-kargs attribute needs to be added to the the VM's Advanced Configuration parameters ($vm.ExtensionData.Config.ExtraConfig). While the govc tool takes care of this detail when using the "-e" flag with the change command, other management tools may require more explicit reference to the Advanced Parameters attributes.  
+The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry. 
+
+NOTE: if you are using a provisioning method other than `govc`, make sure that the guestinfo attribute is provisioned in the VM's Advanced Configuration Parameters (also known as `ExtraConfig`). Some management tools may default to a vApp Property instead, which does not work in this scenario.
 
 [source, bash]
 ----

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -83,7 +83,7 @@ For this reason, on first-boot FCOS instances try to perform network autoconfigu
 If your VMware setup employs static network configuration instead, you can override this automatic DHCP setup with your own custom configuration.
 Custom networking command-line `ip=` parameter can be configured via guestinfo properties as shown below, before booting a VM for the first time.
 
-The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry.
+The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry. Note that the network-kargs attribute needs to be added to the the VM's Advanced Configuration parameters ($vm.ExtensionData.Config.ExtraConfig). While the govc tool takes care of this detail when using the "-e" flag with the change command, other management tools may require more explicit reference to the Advanced Parameters attributes.  
 
 [source, bash]
 ----

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -88,7 +88,7 @@ The provisioning flow follows the usual steps, plus an additional `guestinfo.aft
 [source, bash]
 ----
 VM_NAME='fcos-node02'
-IFACE='ens9'
+IFACE='ens192'
 IPCFG="ip=192.0.2.42::192.0.2.1:255.255.255.0:${VM_NAME}:${IFACE}:off"
 
 govc library.deploy "${LIBRARY}/${TEMPLATE_NAME}" "${VM_NAME}"


### PR DESCRIPTION
Fixed the interface name ('ens192') in the afterburn section. Tested with FCOS 33.20201201.3.0 on vSphere 6.7.