### PR TITLE
storage: document root partition sizing considerations

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -175,6 +175,37 @@ storage:
 
 NOTE: You don't need the `path` or `with_mount_unit` keys; FCOS knows that the root partition is special and will figure out how to find it and mount it.
 
+== Sizing the root partition
+
+If you use Ignition to reconfigure or move the root partition, that partition is not automatically grown on first boot (see related discussions in https://github.com/coreos/fedora-coreos-tracker/issues/570[this issue]). In the case of moving the root partition to a new disk (or multiple disks), you should set the desired partition size using the `size_mib` field. If reconfiguring the root filesystem in place, as in the LUKS example above, you can resize the existing partition using the `resize` field:
+
+.Resizing the root partition to its maximum size
+[source.yaml]
+----
+variant: fcos
+version: 1.2.0
+storage:
+  disks:
+    - device: /dev/vda
+      partitions:
+        - label: root
+          number: 4
+          # 0 means to use all available space
+          size_mib: 0
+          resize: true
+  luks:
+    - name: root
+      device: /dev/disk/by-partlabel/root
+      clevis:
+        tpm2: true
+      wipe_volume: true
+  filesystems:
+    - device: /dev/mapper/root
+      format: xfs
+      wipe_filesystem: true
+      label: root
+----
+
 == Disk Layout
 
 All Fedora CoreOS systems start with the same disk image which varies slightly between architectures based on what is needed for bootloading. On first boot the root filesystem is expanded to fill the rest of the disk. The disk image can be customized using Fedora CoreOS configs to repartition the disk and create/reformat filesystems. Bare metal installations are not different; the installer only copies the raw image to the target disk and injects the specified config into `/boot` for use on first boot.

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -90,7 +90,7 @@ storage:
 
 == Reconfiguring the root filesystem
 
-It is possible to reconfigure the root filesystem itself. You can use the path `/dev/disk/by-label/root` to refer to the original root partition. You must ensure that the new filesystem also has a label of `/root`.
+It is possible to reconfigure the root filesystem itself. You can use the path `/dev/disk/by-label/root` to refer to the original root partition. You must ensure that the new filesystem also has a label of `root`.
 
 NOTE: You must have at least 4G of RAM for root reprovisioning to work.
 


### PR DESCRIPTION
Document that auto-growing is turned off if doing root
reprovisioning. And add an example of how to grow it in the case of
in-place reprovisioning.

Came out of
discussion.fedoraproject.org/t/root-luks-in-ignition/25671.

