### PR TITLE
pxe-artifacts: rootfs image is now mandatory

### DIFF
--- a/modules/ROOT/pages/pxe-artifacts.adoc
+++ b/modules/ROOT/pages/pxe-artifacts.adoc
@@ -1,13 +1,6 @@
 :page-partial:
 
-NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image. Beginning August 12, a third `rootfs` image was added. At present, the `rootfs` image is optional, and Fedora CoreOS displays a warning on login if the system was booted without it. After an initial migration period, the `rootfs` image will be mandatory and the live PXE system will not boot without it.
-
-The migration timeline is:
-
-- August 12: `rootfs` image available in `next`, `testing`, and `stable` streams
-- August 25: `rootfs` image required in `next` stream
-- September 22: `rootfs` image required in `testing` stream
-- October 6: `rootfs` image required in `stable` stream
+NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image. Beginning in August, a third `rootfs` image was added. As of October 6, the `rootfs` image is mandatory and the live PXE system will not boot without it.
 
 To boot with the `rootfs` artifact, make one of the following changes to your PXE config:
 


### PR DESCRIPTION
Update to say that the rootfs is mandatory.  Simplify the presentation of the migration timeline, since the migration is over.