### PR TITLE
check: Log all scanned FCCs in CI; colorize errors/warnings

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Run validator
-        run: ./check.py
+        run: ./check.py -v

--- a/check.py
+++ b/check.py
@@ -13,6 +13,7 @@
 # If variant: is missing, we print a warning but continue, since there
 # might be non-FCC [source,yaml] documents.
 
+import argparse
 import os
 import re
 import subprocess
@@ -22,6 +23,11 @@ import textwrap
 container = os.getenv('FCCT_CONTAINER', 'quay.io/coreos/fcct:release')
 matcher = re.compile(r'^\[source,\s*yaml\]\n----\n(.+?\n)----$',
         re.MULTILINE | re.DOTALL)
+
+parser = argparse.ArgumentParser(description='Run validations on docs.')
+parser.add_argument('-v', '--verbose', action='store_true',
+                    help='log all detected FCCs')
+args = parser.parse_args()
 
 def handle_error(e):
     raise e
@@ -41,6 +47,8 @@ for dirpath, _, filenames in os.walk('.', onerror=handle_error):
             if not fcc.startswith('variant:'):
                 print(f'Ignoring non-FCC at {filepath}:{fccline}')
                 continue
+            if args.verbose:
+                print(f'Checking FCC at {filepath}:{fccline}')
             result = subprocess.run(
                     ['podman', 'run', '--rm', '-i', container, '--strict'],
                     universal_newlines=True, # can be spelled "text" on >= 3.7

--- a/check.py
+++ b/check.py
@@ -37,8 +37,9 @@ def handle_error(e):
     raise e
 
 ret = 0
-for dirpath, _, filenames in os.walk('.', onerror=handle_error):
-    for filename in filenames:
+for dirpath, dirnames, filenames in os.walk('.', onerror=handle_error):
+    dirnames.sort()  # walk in sorted order
+    for filename in sorted(filenames):
         filepath = os.path.join(dirpath, filename)
         if not filename.endswith('.adoc'):
             continue

--- a/check.py
+++ b/check.py
@@ -20,7 +20,8 @@ import sys
 import textwrap
 
 container = os.getenv('FCCT_CONTAINER', 'quay.io/coreos/fcct:release')
-matcher = re.compile(r'^\[source,\s*yaml\]\n----\n(.+?\n)----$', re.MULTILINE | re.DOTALL)
+matcher = re.compile(r'^\[source,\s*yaml\]\n----\n(.+?\n)----$',
+        re.MULTILINE | re.DOTALL)
 
 def handle_error(e):
     raise e

--- a/check.py
+++ b/check.py
@@ -39,7 +39,7 @@ for dirpath, _, filenames in os.walk('.', onerror=handle_error):
             fcc = match.group(1)
             fccline = filedata.count('\n', 0, match.start(1)) + 1
             if not fcc.startswith('variant:'):
-                print(f'Ignoring non-FCC at {filepath} line {fccline}')
+                print(f'Ignoring non-FCC at {filepath}:{fccline}')
                 continue
             result = subprocess.run(
                     ['podman', 'run', '--rm', '-i', container, '--strict'],
@@ -49,6 +49,6 @@ for dirpath, _, filenames in os.walk('.', onerror=handle_error):
                     stderr=subprocess.PIPE)
             if result.returncode != 0:
                 formatted = textwrap.indent(result.stderr.strip(), '  ')
-                print(f'Invalid FCC at {filepath} line {fccline}:\n{formatted}')
+                print(f'Invalid FCC at {filepath}:{fccline}:\n{formatted}')
                 ret = 1
 sys.exit(ret)


### PR DESCRIPTION
Make it easier to verify that a particular FCC has been checked, while keeping the output readable.