### PR TITLE
pages: fix asciidoc syntax

### DIFF
--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -12,14 +12,14 @@ However, it may not always match your specific hardware configuration. In that c
 You can specify multiple `console=` options on the kernel command line. Kernel messages will appear on all of them, however only the last-specified device will be used as the foreground interactive console (i.e. `/dev/console`) for the machine.
 
 [NOTE]
-----
+====
 By default these console parameters are provided, in order:
 
  - `console=tty0` for VGA.
  - `console=ttyS0,115200n8` for serial console
 
 The last entry (serial console) is thus used as the interactive console for the machine.
-----
+====
 
 You can remove either console entries in order to match your machine setup, or even remove both and rely on kernel auto-detection (which however may not work for all cases).
 

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -710,7 +710,7 @@ storage:
 
 NOTE: There is https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/509[a bug]
       that causes the subinterface of the vlan to also try DHCP. We'll workaround by specifying
-      `*ip=${interface}:off*` here to disable it.
+      `*ip=$\{interface}:off*` here to disable it.
 
 .Template
 [source, bash]
@@ -827,12 +827,12 @@ storage:
 NOTE: There is https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/581[a bug]
       that causes the expected Vlan on Bond DHCP syntax to not work for the `*ip=*` argument.
       We'll workaround that bug here by using the `*VLAN_PLUS_VID_NO_PAD*` form of vlan name.
-      So we'll use `*vlan${vlanid}*` instead of `*${bondname}.${vlanid}*`. We'll move back to
+      So we'll use `*vlan$\{vlanid}*` instead of `*$\{bondname}.$\{vlanid}*`. We'll move back to
       the `*DEV_PLUS_VID_NO_PAD*` form when the bug is fixed.
 
 NOTE: There is https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/509[a bug]
       that causes the subinterface of the vlan to also try DHCP. We'll workaround by specifying
-      `*ip=${bondname}:off*` here to disable it.
+      `*ip=$\{bondname}:off*` here to disable it.
 
 
 .Template


### PR DESCRIPTION
This fixes a few formatting warnings related to wrong asciidoc syntax.