### PR TITLE
tutorials: add colon punctuation mark

### DIFF
--- a/modules/ROOT/pages/tutorials.adoc
+++ b/modules/ROOT/pages/tutorials.adoc
@@ -16,4 +16,4 @@ xref:tutorial-containers.adoc[SSH access and starting containers]: In this tutor
 
 xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]: In this tutorial, you will learn how automatic updates are handled in Fedora CoreOS and how to rollback in case of failures.
 
-xref:tutorial-user-systemd-unit-on-boot.adoc[Launching a user-level systemd unit on boot] There are times when it’s helpful to launch a user-level systemd unit without having to log in. This tutorial demonstrates creating a user-level systemd unit that launches on boot. 
+xref:tutorial-user-systemd-unit-on-boot.adoc[Launching a user-level systemd unit on boot]: There are times when it’s helpful to launch a user-level systemd unit without having to log in. This tutorial demonstrates creating a user-level systemd unit that launches on boot. 


### PR DESCRIPTION
Other lines in this page have colon to separate link from description