### PR TITLE
Add macOS instructions for getting fcct

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -65,7 +65,9 @@ alias butane='podman run --rm --tty --interactive \
 
 NOTE: Those examples use podman, but you can use docker in a similar manner.
 
-=== Installing via Fedora packages
+=== Installing via distribution packages
+
+==== Installing on Fedora
 
 Butane is available as a Fedora package:
 
@@ -74,8 +76,18 @@ Butane is available as a Fedora package:
 sudo dnf install -y butane
 ----
 
+==== Installing via Homebrew
+
+Butane is available as a https://brew.sh[Homebrew] package:
+
+[source,bash]
+----
+brew install butane
+----
+
 === Standalone binary
 
+==== Linux
 To use the Butane binary on Linux, follow these steps:
 
 . If you have not already done so, download the https://getfedora.org/security/[Fedora signing keys] and import them:
@@ -90,6 +102,23 @@ curl https://getfedora.org/static/fedora.gpg | gpg --import
 [source,bash]
 ----
 gpg --verify butane-x86_64-unknown-linux-gnu.asc
+----
+
+==== macOS
+To use the Butane binary on macOS, follow these steps:
+
+. If you have not already done so, download the https://getfedora.org/static/fedora.gpg[Fedora signing keys] and import them:
++
+[source,bash]
+----
+curl https://getfedora.org/static/fedora.gpg | gpg --import
+----
+. Download the latest version of Butane and the detached signature from the https://github.com/coreos/butane/releases[releases page].
+. Verify it with gpg:
++
+[source,bash]
+----
+gpg --verify butane-x86_64-apple-darwin.asc
 ----
 
 == A simple example


### PR DESCRIPTION
Split macOS and Linux instructions for installing fcct to be able to cover different package managers such as homebrew.