### PR TITLE
More stream docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -3,6 +3,7 @@
 ** xref:getting-started.adoc[Getting Started]
 ** xref:bare-metal.adoc[Installing on Bare Metal]
 ** Provisioning Machines
+*** xref:stream-metadata.adoc[Stream metadata]
 *** xref:provisioning-aliyun.adoc[Booting on Alibaba Cloud]
 *** xref:provisioning-aws.adoc[Booting on AWS]
 *** xref:provisioning-azure.adoc[Booting on Azure]

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -2,16 +2,16 @@
 
 == Introduction
 
-=== Update Streams
+=== Streams
 
-Metadata about Fedora CoreOS is available in a custom JSON format, called "stream metadata".  For maintaining automation, it is expected that you will interact with this stream metadata.  There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well and provide feedback.
+There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well and provide feedback.
 
-Each stream has a canonical URL representing its current state in JSON format.  For example, the URL for the stable stream is: https://builds.coreos.fedoraproject.org/streams/stable.json
+Each stream has a canonical URL representing its current state in JSON format, known as "stream metadata".  For example, the stream metadata URL for `stable` is: https://builds.coreos.fedoraproject.org/streams/stable.json
 
-While Fedora CoreOS does automatic in-place updates, it is generally a good practice to start provisioning new machines from the latest images.
-The format of this JSON file is stable, and you can parse it to e.g. find the latest ISO/AMI/etc.
+For automating Fedora CoreOS installations, it is expected that you will interact with stream metadata.  While Fedora CoreOS does automatic in-place updates, it is generally a good practice to start provisioning new machines from the latest images.
 
-For more information on streams and switching between them, see xref:update-streams.adoc[Update Streams].
+For more information on using stream metadata, see xref:stream-metadata.adoc[Stream Metadata].
+For more about the available streams, see xref:update-streams.adoc[Update Streams].
 
 === Provisioning Philosophy
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -4,7 +4,7 @@
 
 === Update Streams
 
-There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well.
+Metadata about Fedora CoreOS is available in a custom JSON format, called "stream metadata".  For maintaining automation, it is expected that you will interact with this stream metadata.  There are three Fedora CoreOS (FCOS) update streams available: `stable`, `testing`, and `next`. In general, you will want to use `stable`, but it is recommended to run some machines on `testing` and `next` as well and provide feedback.
 
 Each stream has a canonical URL representing its current state in JSON format.  For example, the URL for the stable stream is: https://builds.coreos.fedoraproject.org/streams/stable.json
 

--- a/modules/ROOT/pages/stream-metadata.adoc
+++ b/modules/ROOT/pages/stream-metadata.adoc
@@ -1,0 +1,40 @@
+
+= Stream metadata
+
+Metadata about Fedora CoreOS is available in a custom JSON format, called "stream metadata".  For maintaining automation, it is expected that you will interact with this stream metadata. 
+
+The format is stable, and intended to be relatively self-documenting.  There is not yet a JSON schema.
+However, in most web browsers, navigating to the URL will render the JSON in an easy-to-read form.
+
+== Canonical URL
+
+The URL for the `stable` stream is: https://builds.coreos.fedoraproject.org/streams/stable.json
+You can similarly replace `stable` here with other available xref:available-update-streams.adoc[Update Streams].
+
+== Using coreos-installer to download
+
+The `coreos-installer` tool has built-in support for fetching artifacts:
+
+[source, bash]
+----
+STREAM='stable'
+coreos-installer download --decompress -s $STREAM -p openstack -f qcow2.xz
+----
+
+== Using coreos/stream-metadata-go
+
+There is an official [coreos/stream-metadata-go](https://github.com/coreos/stream-metadata-go) library for
+software written in the Go programming language.  The README.md file in that repository contains a link to example code.
+
+== Example: Script ec2 CLI
+
+Fetch the latest `x86_64` AMI in `us-west-1` and use it to launch an instance:
+
+[source, bash]
+----
+$ AMI=$(curl -sSL https://builds.coreos.fedoraproject.org/streams/stable.json | jq -r '.architectures.x86_64.images.aws.regions["us-west-1"].image')
+$ echo $AMI
+ami-021238084bf8c95ff
+$ aws ec2 run-instances --region us-west-1 --image-id "${AMI}" ...
+----
+


### PR DESCRIPTION
docs: Elaborate on stream metadata format a bit more in the intro

---

docs: Move update-streams.adoc to available-updates-streams.adoc

In preparation for more cleanly splitting off "what is stream metadata"
from "what are the FCOS streams".

---

Add a stream-metadata doc

Explicitly e.g. link to our Go library, etc.

---

