### PR TITLE
Update for FCCT rename to Butane

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,8 +8,8 @@ on:
     branches: [master]
 
 jobs:
-  fcc:
-    name: Validate FCCs
+  butane:
+    name: Validate Butane configs
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository

--- a/check.py
+++ b/check.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 #
-# Find all FCCs in the doc tree, use the podman FCCT container to run them
-# through fcct --strict, and fail on any errors.
+# Find all Butane configs in the doc tree, use the podman Butane container
+# to run them through butane --strict, and fail on any errors.
 #
-# An FCC looks like this:
+# A Butane config looks like this:
 #
 # [source,yaml]
 # ----
@@ -11,7 +11,7 @@
 # ----
 #
 # If variant: is missing, we print a warning but continue, since there
-# might be non-FCC [source,yaml] documents.
+# might be [source,yaml] documents that aren't Butane configs.
 
 import argparse
 import os
@@ -24,13 +24,13 @@ ERR = '\x1b[1;31m'
 WARN = '\x1b[1;33m'
 RESET = '\x1b[0m'
 
-container = os.getenv('FCCT_CONTAINER', 'quay.io/coreos/fcct:release')
+container = os.getenv('BUTANE_CONTAINER', 'quay.io/coreos/butane:release')
 matcher = re.compile(r'^\[source,\s*yaml\]\n----\n(.+?\n)----$',
         re.MULTILINE | re.DOTALL)
 
 parser = argparse.ArgumentParser(description='Run validations on docs.')
 parser.add_argument('-v', '--verbose', action='store_true',
-                    help='log all detected FCCs')
+                    help='log all detected Butane configs')
 args = parser.parse_args()
 
 def handle_error(e):
@@ -47,17 +47,17 @@ for dirpath, dirnames, filenames in os.walk('.', onerror=handle_error):
             filedata = fh.read()
         # Iterate over YAML source blocks
         for match in matcher.finditer(filedata):
-            fcc = match.group(1)
-            fccline = filedata.count('\n', 0, match.start(1)) + 1
-            if not fcc.startswith('variant:'):
-                print(f'{WARN}Ignoring non-FCC at {filepath}:{fccline}{RESET}')
+            bu = match.group(1)
+            buline = filedata.count('\n', 0, match.start(1)) + 1
+            if not bu.startswith('variant:'):
+                print(f'{WARN}Ignoring non-Butane YAML at {filepath}:{buline}{RESET}')
                 continue
             if args.verbose:
-                print(f'Checking FCC at {filepath}:{fccline}')
+                print(f'Checking Butane config at {filepath}:{buline}')
             result = subprocess.run(
                     ['podman', 'run', '--rm', '-i', container, '--strict'],
                     universal_newlines=True, # can be spelled "text" on >= 3.7
-                    input=fcc,
+                    input=bu,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.PIPE)
             if result.returncode != 0:
@@ -65,6 +65,6 @@ for dirpath, dirnames, filenames in os.walk('.', onerror=handle_error):
                 # Not necessary for ANSI terminals, but required by GitHub's
                 # log renderer
                 formatted = ERR + formatted.replace('\n', '\n' + ERR)
-                print(f'{ERR}Invalid FCC at {filepath}:{fccline}:\n{formatted}{RESET}')
+                print(f'{ERR}Invalid Butane config at {filepath}:{buline}:\n{formatted}{RESET}')
                 ret = 1
 sys.exit(ret)

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -17,7 +17,7 @@
 ** xref:provisioning-vultr.adoc[Booting on Vultr]
 * System Configuration
 ** xref:producing-ign.adoc[Producing an Ignition File]
-** link:https://coreos.github.io/fcct/specs/[FCCT Specification]
+** link:https://coreos.github.io/butane/specs/[Butane Specification]
 ** xref:remote-ign.adoc[Using a remote Ignition config]
 ** xref:storage.adoc[Configuring Storage]
 ** xref:managing-files.adoc[Managing Files]
@@ -57,9 +57,9 @@
 ** xref:update-barrier-signing-keys.adoc[Signing keys and updates]
 * Projects documentation
 ** https://coreos.github.io/afterburn/[Afterburn]
+** https://coreos.github.io/butane/[Butane (Config Transpiler)]
 ** https://coreos.github.io/coreos-assembler/[CoreOS Assembler]
 ** https://coreos.github.io/coreos-installer/[CoreOS Installer]
-** https://coreos.github.io/fcct/[FCCT (Config Transpiler)]
 ** https://coreos.github.io/ignition/[Ignition]
 ** https://coreos.github.io/rpm-ostree/[rpm-ostree]
 ** https://coreos.github.io/zincati/[Zincati]

--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -6,7 +6,7 @@ By default, a privileged user named `core` is created on the Fedora CoreOS syste
 
 == Creating a New User
 
-To create a new user (or users), add it to the `users` list of your Fedora CoreOS Config. In the following example, the config creates two new usernames, but doesn't configure them to be especially useful.
+To create a new user (or users), add it to the `users` list of your Butane config. In the following example, the config creates two new usernames, but doesn't configure them to be especially useful.
 
 [source,yaml]
 ----
@@ -22,7 +22,7 @@ You  will typically want to configure SSH keys or a password, in order to be abl
 
 == Using an SSH Key
 
-To configure an SSH key for a local user, you can use a Fedora CoreOS Config:
+To configure an SSH key for a local user, you can use a Butane config:
 
 [source,yaml]
 ----
@@ -55,7 +55,7 @@ Ignition writes configured SSH keys to `~/.ssh/authorized_keys.d/ignition`. On p
 
 == Using Password Authentication
 
-Fedora CoreOS ships with no default passwords. You can use a Fedora CoreOS Config to set a password for a local user. Building on the previous example, we can configure the `password_hash` for one or more users:
+Fedora CoreOS ships with no default passwords. You can use a Butane config to set a password for a local user. Building on the previous example, we can configure the `password_hash` for one or more users:
 
 [source,yaml]
 ----
@@ -93,7 +93,7 @@ The configured password will be accepted for local authentication at the console
 
 Fedora CoreOS comes with a few groups configured by default: `root`, `adm`, `wheel`, `sudo`, `systemd-journal`, `docker`
 
-When configuring users via Fedora CoreOS Configs, we can specify groups that the user(s) should be a part of.
+When configuring users via Butane configs, we can specify groups that the user(s) should be a part of.
 
 [source,yaml]
 ----
@@ -119,7 +119,7 @@ passwd:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTey7R...
 ----
 
-If a group does not exist, users should create them as part of the Fedora CoreOS Config.
+If a group does not exist, users should create them as part of the Butane config.
 
 [source,yaml]
 ----
@@ -153,7 +153,7 @@ passwd:
 
 == Configuring Administrative Privileges
 
-The easiest way for users to be granted administrative privileges is to have them added to the `sudo` and `wheel` groups as part of the Fedora CoreOS Config.
+The easiest way for users to be granted administrative privileges is to have them added to the `sudo` and `wheel` groups as part of the Butane config.
 
 [source,yaml]
 ----
@@ -189,7 +189,7 @@ passwd:
 
 == Enabling SSH Password Authentication
 
-To enable password authentication via SSH, add the following to your Fedora CoreOS Config:
+To enable password authentication via SSH, add the following to your Butane config:
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/auto-updates.adoc
+++ b/modules/ROOT/pages/auto-updates.adoc
@@ -14,7 +14,7 @@ A custom "rollout wariness" value (see https://github.com/coreos/zincati/blob/ma
 
 The `rollout_wariness` parameter can be set to a floating point value between `0.0` (most eager) and `1.0` (most conservative).
 In order to receive updates very early in the phased rollout cycle, a node can be configured with a low value (e.g. `0.001`).
-This can be done during provisioning by using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
+This can be done during provisioning by using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: configuring Zincati rollout wariness
 [source,yaml]
@@ -43,7 +43,7 @@ The following finalization strategies are available:
 
 A specific finalization strategy can be configured on each node.
 
-The xref:producing-ign.adoc[FCCT] snippet below shows how to define two maintenance windows during weekend days, starting at 22:30 UTC and lasting one hour each:
+The xref:producing-ign.adoc[Butane] snippet below shows how to define two maintenance windows during weekend days, starting at 22:30 UTC and lasting one hour each:
 
 .Example: configuring Zincati updates strategy
 [source,yaml]

--- a/modules/ROOT/pages/auto-updates.adoc
+++ b/modules/ROOT/pages/auto-updates.adoc
@@ -14,7 +14,7 @@ A custom "rollout wariness" value (see https://github.com/coreos/zincati/blob/ma
 
 The `rollout_wariness` parameter can be set to a floating point value between `0.0` (most eager) and `1.0` (most conservative).
 In order to receive updates very early in the phased rollout cycle, a node can be configured with a low value (e.g. `0.001`).
-This can be done during provisioning by using the xref:fcct-config.adoc[FCCT] configuration snippet shown below:
+This can be done during provisioning by using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
 
 .Example: configuring Zincati rollout wariness
 [source,yaml]
@@ -43,7 +43,7 @@ The following finalization strategies are available:
 
 A specific finalization strategy can be configured on each node.
 
-The xref:fcct-config.adoc[FCCT] snippet below shows how to define two maintenance windows during weekend days, starting at 22:30 UTC and lasting one hour each:
+The xref:producing-ign.adoc[FCCT] snippet below shows how to define two maintenance windows during weekend days, starting at 22:30 UTC and lasting one hour each:
 
 .Example: configuring Zincati updates strategy
 [source,yaml]

--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -3,7 +3,7 @@
 == Using a systemd Link File
 You can create a systemd https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
 
-For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
+For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: Customize NIC via systemd Link File
 [source,yaml]
@@ -23,7 +23,7 @@ storage:
 ----
 
 == Using Udev Rules
-Similarly, also through Ignition configs, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", create a https://man7.org/linux/man-pages/man7/udev.7.html[udev rule] at `/etc/udev/rules.d/80-ifname.rules` using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
+Similarly, also through Ignition configs, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", create a https://man7.org/linux/man-pages/man7/udev.7.html[udev rule] at `/etc/udev/rules.d/80-ifname.rules` using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: Customize NIC via Udev Rules
 [source,yaml]

--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -3,7 +3,7 @@
 == Using a systemd Link File
 You can create a systemd https://www.freedesktop.org/software/systemd/man/systemd.link.html[link file] with Ignition configs.
 
-For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:fcct-config.adoc[FCCT] configuration snippet shown below:
+For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
 
 .Example: Customize NIC via systemd Link File
 [source,yaml]
@@ -23,7 +23,7 @@ storage:
 ----
 
 == Using Udev Rules
-Similarly, also through Ignition configs, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", create a https://man7.org/linux/man-pages/man7/udev.7.html[udev rule] at `/etc/udev/rules.d/80-ifname.rules` using the xref:fcct-config.adoc[FCCT] configuration snippet shown below:
+Similarly, also through Ignition configs, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", create a https://man7.org/linux/man-pages/man7/udev.7.html[udev rule] at `/etc/udev/rules.d/80-ifname.rules` using the xref:producing-ign.adoc[FCCT] configuration snippet shown below:
 
 .Example: Customize NIC via Udev Rules
 [source,yaml]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -249,7 +249,7 @@ interaction of both container runtimes with the firewall on the system.
 To prevent making this mistake you can disable `docker` completely by
 masking the `docker.service` systemd unit.
 
-.Example fcct config for disabling docker.service
+.Example Butane config for disabling docker.service
 [source, yaml]
 ----
 variant: fcos
@@ -266,22 +266,22 @@ The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI b
 
 https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss on discussion.fedoraproject.org]
 
-== What's the difference between Ignition and FCCT configurations?
+== What's the difference between Ignition and Butane configurations?
 
 Ignition configuration is a low-level interface used to define the whole set of customizations for an instance.
-It is primarily meant as a machine-friendly interface, with content encoded as JSON and a fixed structure defined via JSON-Schema.
+It is primarily meant as a machine-friendly interface, with content encoded as JSON and a fixed structure defined via JSON Schema.
 This JSON configuration is processed by each FCOS instance upon first boot.
 
 Many high-level tools exist that can produce an Ignition configuration starting from their own specific input formats,
-such as `terraform`, `matchbox`, `openshift-installer`, and `fcct`.
+such as `terraform`, `matchbox`, `openshift-installer`, and Butane.
 
-Fedora CoreOS Configuration Transpiler (`fcct`) is one of such high-level tools.
+Butane is one such high-level tool.
 It is primarily meant as a human-friendly interface, thus defining its own richer configuration entries and using YAML documents as input.
 This YAML configuration is never directly processed by FCOS instances (only the resulting Ignition configuration is).
 
-Although similar, Ignition configurations and FCCT ones do not have the same structure; thus, converting between them is not just a direct YAML-to-JSON translation, but it involves additional logic.
-FCCT exposes several customization helpers (e.g. distribution specific entries and common abstractions) that are not present in Ignition and make the formats not interchangeable.
-Additionally, the different formats (YAML for FCCT, JSON for Ignition) help to avoid mixing up inputs by mistake.
+Although similar, Ignition configurations and Butane ones do not have the same structure; thus, converting between them is not just a direct YAML-to-JSON translation, but it involves additional logic.
+Butane exposes several customization helpers (e.g. distribution specific entries and common abstractions) that are not present in Ignition and make the formats not interchangeable.
+Additionally, the different formats (YAML for Butane, JSON for Ignition) help to avoid mixing up inputs by mistake.
 
 == What is the format of the version number?
 
@@ -322,7 +322,7 @@ _"But, I really want to use it!"_
 We don't recommend it, but if you really want to use it you can just
 unmask and enable it:
 
-.Example fcct config for unmasking dnsmasq.service
+.Example Butane config for unmasking dnsmasq.service
 [source, yaml]
 ----
 variant: fcos
@@ -364,7 +364,7 @@ have a few options:
 - Switch to a newer non-RSA key type.
 - Provide a configuration to your machine that re-enables the insecure key signatures:
 
-.Example fcct config for re-enabling SSH RSA SHA1 key signatures
+.Example Butane config for re-enabling SSH RSA SHA1 key signatures
 [source, yaml]
 ----
 variant: fcos
@@ -414,7 +414,7 @@ To work around this incompatibility, please attempt to apply policy
 modifications dynamically. For example, for an SELinux boolean you can use the
 following systemd unit that executes on every boot:
 
-.Example fcct config for dynamically applying SELinux boolean
+.Example Butane config for dynamically applying SELinux boolean
 [source, yaml]
 ----
 variant: fcos

--- a/modules/ROOT/pages/fcct-config.adoc
+++ b/modules/ROOT/pages/fcct-config.adoc
@@ -1,3 +1,3 @@
 = Content Moved
 
-The content on this page has been moved. For an overview of the FCCT spec, please see the https://coreos.github.io/fcct/specs/[full specification page]. The code examples on this page have been moved to the individual pages for each topic.
+The content on this page has been moved. For an overview of the Butane (formerly FCCT) spec, please see the https://coreos.github.io/butane/specs/[full specification page]. The code examples on this page have been moved to the individual pages for each topic.

--- a/modules/ROOT/pages/hostname.adoc
+++ b/modules/ROOT/pages/hostname.adoc
@@ -1,6 +1,6 @@
 = Setting a Hostname
 
-To set a custom hostname for your system, use the following FCC to write to `/etc/hostname`:
+To set a custom hostname for your system, use the following Butane config to write to `/etc/hostname`:
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -5,7 +5,7 @@
 
 https://www.projectatomic.io/[Fedora Atomic Host] was a system to deploy applications in containers. Existing FAH users are encouraged to migrate to FCOS, as the project has reached its end-of-life.
 
-FAH used `cloud-init` for provisioning, which required users to provide a `cloud-config` file as userdata for configuration of the instance. Since FCOS Ignition and `cloud-init` are different and have overlapping feature sets, it is not trivial to convert `cloud-init` files to Ignition. Currently, there is no tool for this conversion, so you must manually convert `cloud-init` configs to Fedora CoreOS configs. Refer to xref:fcct-config.adoc[FCCT Specification] for an explanation of the available configuration options.
+FAH used `cloud-init` for provisioning, which required users to provide a `cloud-config` file as userdata for configuration of the instance. Since FCOS Ignition and `cloud-init` are different and have overlapping feature sets, it is not trivial to convert `cloud-init` files to Ignition. Currently, there is no tool for this conversion, so you must manually convert `cloud-init` configs to Fedora CoreOS configs. Refer to link:https://coreos.github.io/fcct/specs/[FCCT Specification] for an explanation of the available configuration options.
 
 == Converting `cloud-init` and `cloud-config` userdata
 

--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -22,7 +22,7 @@ ssh_authorized_keys:
   - ssh-rsa ...
 ----
 
-This can be manually translated into a xref:ign-passwd.adoc[`passwd`] node within the FCC file:
+This can be manually translated into a `passwd` node within the FCC file:
 
 .Example of users:
 [source, yaml]
@@ -42,4 +42,4 @@ NOTE: Fedora CoreOS disables password login over SSH by default. It is strongly 
 
 == Converting storage definitions
 
-With FAH, you could configure additional storage for the system with either `cloud-init` or  `docker-storage-setup` via the `/etc/sysconfig/docker-storage-setup` file. With FCOS, you should configure additional storage at provisioning time via Ignition in the xref:ign-storage.adoc[`storage`] node of the FCC file.
+With FAH, you could configure additional storage for the system with either `cloud-init` or  `docker-storage-setup` via the `/etc/sysconfig/docker-storage-setup` file. With FCOS, you should configure additional storage at provisioning time via Ignition in the `storage` node of the FCC file.

--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -5,11 +5,11 @@
 
 https://www.projectatomic.io/[Fedora Atomic Host] was a system to deploy applications in containers. Existing FAH users are encouraged to migrate to FCOS, as the project has reached its end-of-life.
 
-FAH used `cloud-init` for provisioning, which required users to provide a `cloud-config` file as userdata for configuration of the instance. Since FCOS Ignition and `cloud-init` are different and have overlapping feature sets, it is not trivial to convert `cloud-init` files to Ignition. Currently, there is no tool for this conversion, so you must manually convert `cloud-init` configs to Fedora CoreOS configs. Refer to link:https://coreos.github.io/fcct/specs/[FCCT Specification] for an explanation of the available configuration options.
+FAH used `cloud-init` for provisioning, which required users to provide a `cloud-config` file as userdata for configuration of the instance. Since FCOS Ignition and `cloud-init` are different and have overlapping feature sets, it is not trivial to convert `cloud-init` files to Ignition. Currently, there is no tool for this conversion, so you must manually convert `cloud-init` configs to Butane configs. Refer to link:https://coreos.github.io/butane/specs/[Butane Specification] for an explanation of the available configuration options.
 
 == Converting `cloud-init` and `cloud-config` userdata
 
-The following examples show the difference between FAH userdata and user configuration with FCC.
+The following examples show the difference between FAH userdata and user configuration with Butane.
 
 .Example of FAH userdata file:
 ----
@@ -22,7 +22,7 @@ ssh_authorized_keys:
   - ssh-rsa ...
 ----
 
-This can be manually translated into a `passwd` node within the FCC file:
+This can be manually translated into a `passwd` node within the Butane config:
 
 .Example of users:
 [source, yaml]
@@ -42,4 +42,4 @@ NOTE: Fedora CoreOS disables password login over SSH by default. It is strongly 
 
 == Converting storage definitions
 
-With FAH, you could configure additional storage for the system with either `cloud-init` or  `docker-storage-setup` via the `/etc/sysconfig/docker-storage-setup` file. With FCOS, you should configure additional storage at provisioning time via Ignition in the `storage` node of the FCC file.
+With FAH, you could configure additional storage for the system with either `cloud-init` or  `docker-storage-setup` via the `/etc/sysconfig/docker-storage-setup` file. With FCOS, you should configure additional storage at provisioning time via Ignition in the `storage` node of the Butane config.

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -6,7 +6,7 @@ Fedora CoreOS is the official successor of CoreOS Container Linux, which https:/
 
 == Introduction
 
-To migrate from CL to FCOS, you must convert your old Container Linux Configs, Ignition configs, or `cloud-config` files to a xref:producing-ign.adoc[Fedora CoreOS Config (FCC)] and adapt the contents for FCOS. Since many of the configuration details have changed, you should reference this page and the https://github.com/coreos/fedora-coreos-tracker/issues/159[CL migration issue] on GitHub.
+To migrate from CL to FCOS, you must convert your old Container Linux Configs, Ignition configs, or `cloud-config` files to a xref:producing-ign.adoc[Butane config] and adapt the contents for FCOS. Since many of the configuration details have changed, you should reference this page and the https://github.com/coreos/fedora-coreos-tracker/issues/159[CL migration issue] on GitHub.
 
 == Installation changes
 
@@ -30,7 +30,7 @@ The following changes have been made to the installation process:
 
 == Configuration changes
 
-When writing FCC files, note the following changes:
+When writing Butane configs, note the following changes:
 
 * `coreos-metadata` is now https://github.com/coreos/afterburn/blob/master/README.md[Afterburn]. The prefix of the metadata variable names has changed from `COREOS_` to `AFTERBURN_`, and the following platform names have changed:
 ** `EC2` is now `AWS`
@@ -40,8 +40,8 @@ For more info, see the https://github.com/coreos/afterburn/blob/master/docs/usag
 
 * By default, FCOS does not allow password logins via SSH. We recommend xref:authentication.adoc#using-an-ssh-key[configuring SSH keys] instead. If needed, you can xref:authentication.adoc#enabling-ssh-password-authentication[enable SSH password authentication].
 * Because `usermod` is not yet fully-functional on FCOS, there is a `docker` group in the `/etc/group` file. This is a stop-gap measure to facilitate a smooth transition to FCOS. The team is working on a more functional `usermod`, at which time the `docker` group will no longer be included by default. See the https://github.com/coreos/fedora-coreos-tracker/issues/2[docker group issue].
-* There is no way to create directories below the `/` directory. Changes are restricted to `/etc` and `/var`. Refer to the documentation for the `storage` node of the FCC configuration for details about writing directories and files to FCOS.
-* FCCs no longer have a separate section for network configuration. Use the FCC `files` section to write a https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager key file] instead.
+* There is no way to create directories below the `/` directory. Changes are restricted to `/etc` and `/var`. Refer to the documentation for the `storage` node of the Butane config for details about writing directories and files to FCOS.
+* Butane configs no longer have a separate section for network configuration. Use the Butane `files` section to write a https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager key file] instead.
 
 == Operator notes
 

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -40,7 +40,7 @@ For more info, see the https://github.com/coreos/afterburn/blob/master/docs/usag
 
 * By default, FCOS does not allow password logins via SSH. We recommend xref:authentication.adoc#using-an-ssh-key[configuring SSH keys] instead. If needed, you can xref:authentication.adoc#enabling-ssh-password-authentication[enable SSH password authentication].
 * Because `usermod` is not yet fully-functional on FCOS, there is a `docker` group in the `/etc/group` file. This is a stop-gap measure to facilitate a smooth transition to FCOS. The team is working on a more functional `usermod`, at which time the `docker` group will no longer be included by default. See the https://github.com/coreos/fedora-coreos-tracker/issues/2[docker group issue].
-* There is no way to create directories below the `/` directory. Changes are restricted to `/etc` and `/var`. Refer to the documentation for the xref:ign-storage.adoc[`storage`] node of the FCC configuration for details about writing directories and files to FCOS.
+* There is no way to create directories below the `/` directory. Changes are restricted to `/etc` and `/var`. Refer to the documentation for the `storage` node of the FCC configuration for details about writing directories and files to FCOS.
 * FCCs no longer have a separate section for network configuration. Use the FCC `files` section to write a https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager key file] instead.
 
 == Operator notes

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -6,7 +6,7 @@ Fedora CoreOS is the official successor of CoreOS Container Linux, which https:/
 
 == Introduction
 
-To migrate from CL to FCOS, you must convert your old Container Linux Configs, Ignition configs, or `cloud-config` files to a xref:fcct-config.adoc[Fedora CoreOS Config (FCC)] and adapt the contents for FCOS. Since many of the configuration details have changed, you should reference this page and the https://github.com/coreos/fedora-coreos-tracker/issues/159[CL migration issue] on GitHub.
+To migrate from CL to FCOS, you must convert your old Container Linux Configs, Ignition configs, or `cloud-config` files to a xref:producing-ign.adoc[Fedora CoreOS Config (FCC)] and adapt the contents for FCOS. Since many of the configuration details have changed, you should reference this page and the https://github.com/coreos/fedora-coreos-tracker/issues/159[CL migration issue] on GitHub.
 
 == Installation changes
 

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -10,73 +10,73 @@ Ignition runs only once during the first boot of the system (while in the initra
 
 Ignition configurations are formatted as JSON, which is quick and easy for a machine to read. However, these files are not easy for humans to read or write. The solution is a two-step configuration process that is friendly for both humans and machines:
 
-. Produce a YAML-formatted Fedora CoreOS Configuration (FCC) file.
-. Run the Fedora CoreOS Configuration Transpiler (`fcct`) to convert the YAML file into a JSON Ignition file.
+. Produce a YAML-formatted Butane config.
+. Run Butane to convert the YAML file into a JSON Ignition config.
 
-During the transpilation process, `fcct` verifies the syntax of the YAML file, which can catch errors before you use it to launch the FCOS system.
+During the transpilation process, Butane verifies the syntax of the YAML file, which can catch errors before you use it to launch the FCOS system.
 
 Once you have an Ignition (`.ign`) file, you can use it to boot an FCOS system in a VM or install it on bare metal.
 
 TIP: Try to plan your configuration with the full set of customization details before provisioning a Fedora CoreOS instance. But don't worry if you forgot something as you can simply fix the configuration and re-deploy the instance from a fresh image.
 
-== Getting FCCT
+== Getting Butane
 
-You can run `fcct` as a container with docker or podman or download it as a standalone binary.
+You can run Butane as a container with docker or podman or download it as a standalone binary.
 
-NOTE: Unless otherwise noted, new releases of `fcct` are backwards compatible with old releases.
+NOTE: Unless otherwise noted, new releases of Butane are backwards compatible with old releases.
 
 === Via a container with `podman` or `docker`
 
-You can get `fccŧ` from a container hosted on https://quay.io/[quay.io]:
+You can get Butane from a container hosted on https://quay.io/[quay.io]:
 
 [source,bash]
 ----
-podman pull quay.io/coreos/fcct:release
+podman pull quay.io/coreos/butane:release
 ----
 
 NOTE: The `release` tag tracks the most recent release, and the `latest` tag tracks the Git development branch.
 
-Run `fcct` either by using standard in and standard out or by using files:
+Run Butane either by using standard input and standard output or by using files:
 
-.Example running `fcct` using standard in and standard out:
+.Example running Butane using standard input and standard output
 [source,bash]
 ----
-podman run --interactive --rm quay.io/coreos/fcct:release \
-       --pretty --strict < your_config.fcc > transpiled_config.ign
+podman run --interactive --rm quay.io/coreos/butane:release \
+       --pretty --strict < your_config.bu > transpiled_config.ign
 ----
 
-.Example running `fcct` using a file as input and standard out:
+.Example running Butane using a file as input and standard output
 [source,bash]
 ----
 podman run --interactive --rm --security-opt label=disable \
-       --volume ${PWD}:/pwd --workdir /pwd quay.io/coreos/fcct:release \
-       --pretty --strict your_config.fcc > transpiled_config.ign
+       --volume ${PWD}:/pwd --workdir /pwd quay.io/coreos/butane:release \
+       --pretty --strict your_config.bu > transpiled_config.ign
 ----
 
 To make it simpler to type, you may also add the following alias to your shell configuration:
 
 [source,bash]
 ----
-alias fcct='podman run --rm --tty --interactive \
-            --security-opt label=disable        \
-            --volume ${PWD}:/pwd --workdir /pwd \
-            quay.io/coreos/fcct:release'
+alias butane='podman run --rm --tty --interactive \
+              --security-opt label=disable        \
+              --volume ${PWD}:/pwd --workdir /pwd \
+              quay.io/coreos/butane:release'
 ----
 
 NOTE: Those examples use podman, but you can use docker in a similar manner.
 
 === Installing via Fedora packages
 
-`fcct` is available as Fedora a package:
+Butane is available as a Fedora package:
 
 [source,bash]
 ----
-sudo dnf install -y fcct
+sudo dnf install -y butane
 ----
 
 === Standalone binary
 
-To use the `fcct` binary on Linux, follow these steps:
+To use the Butane binary on Linux, follow these steps:
 
 . If you have not already done so, download the https://getfedora.org/security/[Fedora signing keys] and import them:
 +
@@ -84,22 +84,22 @@ To use the `fcct` binary on Linux, follow these steps:
 ----
 curl https://getfedora.org/static/fedora.gpg | gpg --import
 ----
-. Download the latest version of `fcct` and the detached signature from the https://github.com/coreos/fcct/releases[releases page].
+. Download the latest version of Butane and the detached signature from the https://github.com/coreos/butane/releases[releases page].
 . Verify it with gpg:
 +
 [source,bash]
 ----
-gpg --verify fcct-x86_64-unknown-linux-gnu.asc
+gpg --verify butane-x86_64-unknown-linux-gnu.asc
 ----
 
 == A simple example
 
-Create a basic Ignition file that modifies the default Fedora CoreOS user `core` to allow this user login with an SSH key.
+Create a basic Ignition config that modifies the default Fedora CoreOS user `core` to allow this user to log in with an SSH key.
 
 The overall steps are as follows:
 
-. Write the Fedora CoreOS Configuration (FCC) file in the YAML format.
-. Use the `fcct` to convert the FCC file into an Ignition (JSON) file.
+. Write the Butane config in the YAML format.
+. Use Butane to convert the Butane config into an Ignition (JSON) config.
 . Boot a fresh Fedora CoreOS image with the resulting Ignition configuration.
 
 === Prerequisite
@@ -108,7 +108,7 @@ This example uses a pair of SSH public and private keys. If you don't already ha
 
 The SSH public key will be provisioned to the Fedora CoreOS machine (via Ignition). The SSH private key needs to be available to your user on the local workstation, in order to remotely authenticate yourself over SSH.
 
-=== Writing the FCC file
+=== Writing the Butane config
 
 . Copy the following example into a text editor:
 +
@@ -125,17 +125,17 @@ passwd:
 +
 . Replace the above line starting with `ssh-rsa` with the contents of your SSH public key file.
 +
-. Save the file with the name `example.fcc`.
+. Save the file with the name `example.bu`.
 
-TIP: YAML files must have consistent indentation. Although `fcct` checks for syntax errors, ensure that the indentation matches the above example. Overall, the FCC files must conform to ``fcct``'s https://coreos.github.io/fcct/specs/[configuration specification] format.
+TIP: YAML files must have consistent indentation. Although Butane checks for syntax errors, ensure that the indentation matches the above example. Overall, the Butane configs must conform to Butane's https://coreos.github.io/butane/specs/[configuration specification] format.
 
-=== Using FCCT
+=== Using Butane
 
-. Run fcct on the FCC file:
+. Run Butane on the Butane config:
 +
 [source,bash]
 ----
-fcct --pretty --strict < example.fcc > example.ign
+butane --pretty --strict < example.bu > example.ign
 ----
 +
 . Use the `example.ign` file to xref:getting-started.adoc[boot Fedora CoreOS].

--- a/modules/ROOT/pages/running-containers.adoc
+++ b/modules/ROOT/pages/running-containers.adoc
@@ -4,7 +4,7 @@
 Fedora CoreOS ships with both docker and podman installed. This page explains how to use systemd units to start and stop containers with podman.
 
 == Example configuration
-The following FCOS Configuration (FCC) snippet configures the systemd hello.service to run busybox.
+The following Butane config snippet configures the systemd hello.service to run busybox.
 
 .Example for running busybox using systemd and podman
 [source,yaml]
@@ -36,7 +36,7 @@ systemd:
 
 etcd is not shipped as part of Fedora CoreOS. To use it, run it as a container, as shown below.
 
-.FCC for setting up single node etcd
+.Butane config for setting up single node etcd
 [source,yaml]
 ----
 variant: fcos

--- a/modules/ROOT/pages/static-ip-config.adoc
+++ b/modules/ROOT/pages/static-ip-config.adoc
@@ -1,7 +1,7 @@
 = Configuring FCOS to Use a Static IP Address
 By default, an FCOS instance will attempt to grab a DHCP address from the local network. However, if you need FCOS to use a static IP address, you can do so by specifying the NetworkManager configuration in the Ignition configuration file.
 
-As with any custom configuration on FCOS, you can write specific files in the xref:ign-storage.adoc[`storage` node] of the Ignition file.
+As with any custom configuration on FCOS, you can write specific files in the `storage` of the Ignition file.
 
 The following snippet shows how to assign a static configuration to `enp1s0`:
 

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -23,7 +23,7 @@ For physical hardware, a good best practice is to reference devices via the `/de
 
 == Setting up separate /var mounts
 
-Here's an example FCC file to set up `/var` on a separate partition on the same primary disk:
+Here's an example Butane config to set up `/var` on a separate partition on the same primary disk:
 
 .Adding a /var partition to the primary disk
 [source,yaml]
@@ -54,8 +54,8 @@ storage:
       device: /dev/disk/by-partlabel/var
       # We can select the filesystem we'd like.
       format: ext4
-      # Ask FCCT to generate a mount unit for us so that this filesystem gets
-      # mounted in the real root.
+      # Ask Butane to generate a mount unit for us so that this filesystem
+      # gets mounted in the real root.
       with_mount_unit: true
 ----
 
@@ -184,7 +184,7 @@ storage:
 
 NOTE: You don't need the `path` or `with_mount_unit` keys; FCOS knows that the root partition is special and will figure out how to find it and mount it.
 
-If you want to replicate the boot disk across multiple drives for resiliency to drive failure, you need to mirror all of the default partitions (root, boot, EFI System Partition, and bootloader code).  There is special FCC syntax for this:
+If you want to replicate the boot disk across multiple drives for resiliency to drive failure, you need to mirror all of the default partitions (root, boot, EFI System Partition, and bootloader code).  There is special Butane config syntax for this:
 
 .Mirroring the boot disk onto two drives
 [source,yaml]
@@ -264,7 +264,7 @@ storage:
       with_mount_unit: true
 ----
 
-The root filesystem can also be moved to LUKS. In the case of the root filesystem the LUKS device must be backed by https://github.com/coreos/ignition/blob/master/docs/operator-notes.md#clevis-based-devices[clevis]. There is simplified FCC syntax for encrypting the root filesystem; for example:
+The root filesystem can also be moved to LUKS. In the case of the root filesystem the LUKS device must be backed by https://github.com/coreos/ignition/blob/master/docs/operator-notes.md#clevis-based-devices[clevis]. There is simplified Butane config syntax for encrypting the root filesystem; for example:
 
 .Moving the root filesystem to LUKS
 [source,yaml]
@@ -335,7 +335,7 @@ storage:
 
 This example creates a swap partition spanning all of the `sdb` device, creates a swap area on it, and creates a systemd swap unit so the swap area is enabled on boot.
 
-NOTE: Using `with_mount_unit: true` with `format: swap` requires FCC spec version `1.4.0-experimental`.  After spec 1.4.0 is stabilized, version `1.4.0-experimental` will no longer be accepted by FCCT and configs that use it will need to be updated.
+NOTE: Using `with_mount_unit: true` with `format: swap` requires Butane spec version `1.4.0-experimental`.  After spec 1.4.0 is stabilized, version `1.4.0-experimental` will no longer be accepted by Butane and configs that use it will need to be updated.
 
 .Configuring a swap partition on a second disk
 [source,yaml]
@@ -410,7 +410,7 @@ storage:
 
 == Disk Layout
 
-All Fedora CoreOS systems start with the same disk image which varies slightly between architectures based on what is needed for bootloading. On first boot the root filesystem is expanded to fill the rest of the disk. The disk image can be customized using Fedora CoreOS Configs to repartition the disk and create/reformat filesystems. Bare metal installations are not different; the installer only copies the raw image to the target disk and injects the specified config into `/boot` for use on first boot.
+All Fedora CoreOS systems start with the same disk image which varies slightly between architectures based on what is needed for bootloading. On first boot the root filesystem is expanded to fill the rest of the disk. The disk image can be customized using Butane configs to repartition the disk and create/reformat filesystems. Bare metal installations are not different; the installer only copies the raw image to the target disk and injects the specified config into `/boot` for use on first boot.
 
 NOTE: See xref:#_reconfiguring_the_root_filesystem[Reconfiguring the root filesystem] for examples regarding the supported changes to the root partition.
 

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -94,7 +94,7 @@ Networking configuration can be performed by writing out files described in an I
 
 Any configuration provided via Ignition will be considered at a higher priority than any other method of configuring the Network for a Fedora CoreOS instance. If you specify Networking configuration via Ignition, try not to use other mechanisms to configure the network.
 
-An example https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/[FCC] configuration for the same static networking example that we showed above is:
+An example https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/[Butane] config for the same static networking example that we showed above is:
 
 [source, yaml]
 ----
@@ -121,7 +121,7 @@ storage:
 
 == Host Network Configuration Examples
 
-In this section we'll go through common examples of setting up different types of networking devices using both dracut kernel arguments as well as NetworkManager keyfiles via Ignition/FCCT.
+In this section we'll go through common examples of setting up different types of networking devices using both dracut kernel arguments as well as NetworkManager keyfiles via Ignition/Butane.
 
 Examples in this section that use a static IP will assume these values unless otherwise stated:
 
@@ -235,7 +235,7 @@ ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver}
 ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens2:none:8.8.8.8
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]
@@ -305,7 +305,7 @@ ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:bond0:none:8.8.8.8
 bond=bond0:ens2,ens3:mode=active-backup,miimon=100
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]
@@ -420,7 +420,7 @@ ip=br0:dhcp
 bridge=br0:ens2,ens3
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]
@@ -529,7 +529,7 @@ ip=team0:dhcp
 team=team0:ens2,ens3
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]
@@ -648,7 +648,7 @@ ip=ens2:off
 vlan=ens2.100:ens2
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]
@@ -767,7 +767,7 @@ bond=bond0:ens2,ens3:mode=active-backup,miimon=100
 vlan=vlan100:bond0
 ----
 
-==== FCC for Ignition
+==== Butane config
 
 .Template
 [source, yaml]

--- a/modules/ROOT/pages/sysctl.adoc
+++ b/modules/ROOT/pages/sysctl.adoc
@@ -5,7 +5,7 @@ The Linux kernel offers a plethora of knobs under `/proc/sys` to control the ava
 Values under `/proc/sys` can be changed directly at runtime, but such changes will not be persisted across reboots.
 Persistent settings should be written under `/etc/sysctl.d/` during provisioning, in order to be applied on each boot.
 
-As an example, the https://coreos.github.io/fcct/[FCCT] snippet below shows how to disable _SysRq_ keys:
+As an example, the xref:producing-ign.adoc[Butane] snippet below shows how to disable _SysRq_ keys:
 
 .Example: configuring kernel tunable to disable SysRq keys
 [source,yaml]

--- a/modules/ROOT/pages/tutorial-autologin.adoc
+++ b/modules/ROOT/pages/tutorial-autologin.adoc
@@ -6,11 +6,11 @@ NOTE: Make sure that you have completed the steps described in the xref:tutorial
 
 Fedora CoreOS does not have a separate install disk. Instead, every instance starts from a generic disk image which is customized on first boot via https://github.com/coreos/ignition[Ignition].
 
-Ignition config files are written in JSON but are typically not user friendly. Configurations are thus written in a simpler format, Fedora CoreOS Config, that is then converted into an Ignition config. The tool responsible for converting Fedora CoreOS Configs into Ignition configs is called the Fedora CoreOS Config Transpiler (or FCCT).
+Ignition config files are written in JSON but are typically not user friendly. Configurations are thus written in a simpler format, the Butane config, that is then converted into an Ignition config. The tool responsible for converting Butane configs into Ignition configs is naturally called Butane.
 
-== First Ignition config via FCCT
+== First Ignition config via Butane
 
-Let's create a very simple Fedora CoreOS config that will perform the following actions:
+Let's create a very simple Butane config that will perform the following actions:
 
 - Add a systemd dropin to override the default `serial-getty@ttyS0.service`.
     - The override will make the service automatically log the `core` user in to the serial console of the booted machine.
@@ -18,7 +18,7 @@ Let's create a very simple Fedora CoreOS config that will perform the following 
 - Add a bash profile that tells systemd to not use a pager for output.
 - Raise kernel console logging level to hide audit messages from the console.
 
-We can create a config file named `fcct-autologin.yaml` now as:
+We can create a config file named `autologin.bu` now as:
 
 [source,yaml]
 ----
@@ -57,14 +57,14 @@ storage:
           kernel.printk=4
 ----
 
-This configuration can then be converted into an Ignition config with `fcct`:
+This configuration can then be converted into an Ignition config with Butane:
 
 [source,bash]
 ----
-$ fcct --pretty --strict fcct-autologin.yaml --output autologin.ign
+$ butane --pretty --strict autologin.bu --output autologin.ign
 ----
 
-The resulting Ignition configuration produced by `fcct` as `autologin.ign` has the following content:
+The resulting Ignition configuration produced by Butane as `autologin.ign` has the following content:
 
 [source,json]
 ----
@@ -113,7 +113,7 @@ The resulting Ignition configuration produced by `fcct` as `autologin.ign` has t
 }
 ----
 
-Luckily `fcct` outputs valid Ignition configs. However, if you are tweaking the config after `fcct`, or manually creating Ignition configs, you will have to verify that the config format is valid with `ignition-validate`:
+Butane outputs valid Ignition configs. However, if you are tweaking the config after Butane, or manually creating Ignition configs, you will have to verify that the config format is valid with `ignition-validate`:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -10,9 +10,9 @@ As usual we will setup console autologin, a hostname, systemd pager configuratio
 * Add a systemd service (`failure.service`) that fails on boot.
 * Add a systemd service that will use a container to bring up a hosted service.
 
-== Writing the Fedora CoreOS config and converting to Ignition
+== Writing the Butane config and converting to Ignition
 
-Similarly to what we did in the second provisioning scenario, we will write the following Fedora CoreOS config in a file called `fcct-containers.yaml`:
+Similarly to what we did in the second provisioning scenario, we will write the following Butane config in a file called `containers.bu`:
 
 [source,yaml]
 ----
@@ -95,11 +95,11 @@ storage:
 
 TIP: Optionally you can replace the SSH pubkey in the yaml file with your own public key so you can log in to the booted instance. If you choose not to do this you'll still be auto logged in to the serial console.
 
-Run `fcct` to convert that to an Ignition config:
+Run Butane to convert that to an Ignition config:
 
 [source,bash]
 ----
-fcct --pretty --strict fcct-containers.yaml --output containers.ign
+butane --pretty --strict containers.bu --output containers.ign
 ----
 
 Now let's provision it:

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -2,7 +2,7 @@
 
 NOTE: Make sure that you have completed the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial.
 
-In this tutorial, we will run a script on the first boot via a systemd service. We will add the following to the Fedora CoreOS config from the previous scenario:
+In this tutorial, we will run a script on the first boot via a systemd service. We will add the following to the Butane config from the previous scenario:
 
 * Add a script at `/usr/local/bin/public-ipv4.sh`.
 * Configure a systemd service to run the script on first boot.
@@ -43,11 +43,11 @@ RemainAfterExit=yes
 WantedBy=console-login-helper-messages-issuegen.service
 ----
 
-We will call this unit `issuegen-public-ipv4.service` and we will embed it into the Fedora CoreOS config in the next section.
+We will call this unit `issuegen-public-ipv4.service` and we will embed it into the Butane config in the next section.
 
-== Writing the Fedora CoreOS config and converting to Ignition
+== Writing the Butane config and converting to Ignition
 
-We can now create a Fedora CoreOS config by including the script and the systemd unit directly as inline content into the systemd/units and storage/files sections. The final Fedora CoreOS config, stored in `fcct-services.yaml`, will be:
+We can now create a Butane config by including the script and the systemd unit directly as inline content into the systemd/units and storage/files sections. The final Butane config, stored in `services.bu`, will be:
 
 [source,yaml]
 ----
@@ -113,7 +113,7 @@ And then convert to Ignition:
 
 [source,bash]
 ----
-fcct --pretty --strict fcct-services.yaml --output services.ign
+butane --pretty --strict services.bu --output services.ign
 ----
 
 == Testing

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -8,8 +8,8 @@ These tutorials are written targeting a Linux environment with a working `libvir
 
 For the tutorials, we will need the following tools:
 
+  * Butane: To generate Ignition configuration from Butane config files.
   * `coreos-installer`: To download the latest Fedora CoreOS QCOW2 image.
-  * `fcct`: To generate Ignition configuration from Fedora CoreOS Config files.
   * `ignition-validate`: To validate Ignition configuration files.
 
 To keep all configurations files and Fedora CoreOS images in the same place, we will create a new directory to work from:
@@ -26,8 +26,8 @@ All of the tools required to work with Fedora CoreOS are available from containe
 
 [source,bash]
 ----
+podman pull quay.io/coreos/butane:release
 podman pull quay.io/coreos/coreos-installer:release
-podman pull quay.io/coreos/fcct:release
 podman pull quay.io/coreos/ignition-validate:release
 ----
 
@@ -35,6 +35,11 @@ To make it simpler to type, you may add the following aliases to your shell conf
 
 [source,bash]
 ----
+alias butane='podman run --rm --tty --interactive \
+              --security-opt label=disable        \
+              --volume ${PWD}:/pwd --workdir /pwd \
+              quay.io/coreos/butane:release'
+
 alias coreos-installer='podman run --pull=always            \
                         --rm --tty --interactive            \
                         --security-opt label=disable        \
@@ -45,11 +50,6 @@ alias ignition-validate='podman run --rm --tty --interactive \
                          --security-opt label=disable        \
                          --volume ${PWD}:/pwd --workdir /pwd \
                          quay.io/coreos/ignition-validate:release'
-
-alias fcct='podman run --rm --tty --interactive \
-            --security-opt label=disable        \
-            --volume ${PWD}:/pwd --workdir /pwd \
-            quay.io/coreos/fcct:release'
 ----
 
 You can then use `coreos-installer` to download the latest stable image with:
@@ -70,12 +70,12 @@ You are now ready to proceed with the xref:tutorial-autologin.adoc[first tutoria
 
 === Installing via Fedora packages
 
-All three tools (`coreos-installer`, `fcct` and `ignition-validate`) are available as Fedora packages:
+All three tools (Butane, `coreos-installer`, and `ignition-validate`) are available as Fedora packages:
 
 [source,bash]
 ----
 # Installing the tools
-sudo dnf install -y coreos-installer fcct ignition-validate
+sudo dnf install -y butane coreos-installer ignition-validate
 
 # Downloading the latest Fedora CoreOS stable QCOW2 image
 coreos-installer download -p qemu -f qcow2.xz --decompress
@@ -123,16 +123,16 @@ To make the tutorial simpler, you should rename the image that we have just down
 mv fedora-coreos-32.20200715.3.0-qemu.x86_64.qcow2 fedora-coreos.qcow2
 ----
 
-You should then download the latest https://github.com/coreos/fcct/releases[fcct] and https://github.com/coreos/ignition/releases[ignition-validate] releases from GitHub:
+You should then download the latest https://github.com/coreos/butane/releases[Butane] and https://github.com/coreos/ignition/releases[ignition-validate] releases from GitHub:
 
 [source,bash]
 ----
-# fcct
-curl -OL https://github.com/coreos/fcct/releases/download/v0.6.0/fcct-x86_64-unknown-linux-gnu
-curl -OL https://github.com/coreos/fcct/releases/download/v0.6.0/fcct-x86_64-unknown-linux-gnu.asc
-gpg --verify fcct-x86_64-unknown-linux-gnu.asc
-mv fcct-x86_64-unknown-linux-gnu fcct
-chmod a+x fcct
+# Butane
+curl -OL https://github.com/coreos/butane/releases/download/v0.11.0/butane-x86_64-unknown-linux-gnu
+curl -OL https://github.com/coreos/butane/releases/download/v0.11.0/butane-x86_64-unknown-linux-gnu.asc
+gpg --verify butane-x86_64-unknown-linux-gnu.asc
+mv butane-x86_64-unknown-linux-gnu butane
+chmod a+x butane
 
 # ignition-validate
 curl -OL https://github.com/coreos/ignition/releases/download/v2.5.0/ignition-validate-x86_64-linux
@@ -142,11 +142,11 @@ mv ignition-validate-x86_64-linux ignition-validate
 chmod a+x ignition-validate
 ----
 
-You may then setup aliases for `fcct` and `ignition-validate`:
+You may then setup aliases for `butane` and `ignition-validate`:
 
 [source,bash]
 ----
-alias fcct="${PWD}/fcct"
+alias butane="${PWD}/butane"
 alias ignition-validate="${PWD}/ignition-validate"
 ----
 
@@ -154,9 +154,9 @@ Or move those commands to a folder in your `$PATH`, for example:
 
 [source,bash]
 ----
-mv fcct ignition-validate "${HOME}/.local/bin/"
+mv butane ignition-validate "${HOME}/.local/bin/"
 # Or
-mv fcct ignition-validate "${HOME}/bin"
+mv butane ignition-validate "${HOME}/bin"
 ----
 
 You are now ready to proceed with the xref:tutorial-autologin.adoc[first tutorial].

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -38,15 +38,15 @@ To make the tutorial simpler, you should rename this image to a shorter name:
 mv fedora-coreos-$RELEASE-qemu.x86_64.qcow2 fedora-coreos-older.qcow2
 ----
 
-== Writing the Fedora CoreOS config and converting to Ignition
+== Writing the Butane config and converting to Ignition
 
-We will create a Fedora CoreOS config that:
+We will create a Butane config that:
 
 * Sets up console autologin.
 * Raise kernel console logging level to hide audit messages from the console.
 * Add an SSH Key for the `core` user.
 
-Let's write this Fedora CoreOS config to a file called `fcct-updates.yaml`:
+Let's write this Butane config to a file called `updates.bu`:
 
 [source,yaml]
 ----
@@ -88,11 +88,11 @@ storage:
 
 TIP: Optionally you can replace the SSH pubkey in the yaml file with your own public key so you can log in to the booted instance. If you choose not to do this you'll still be auto logged in to the serial console.
 
-Run `fcct` to convert that to an Ignition config:
+Run Butane to convert that to an Ignition config:
 
 [source,bash]
 ----
-fcct --pretty --strict fcct-updates.yaml --output updates.ign
+butane --pretty --strict updates.bu --output updates.ign
 ----
 
 == Startup and initial update

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -2,7 +2,7 @@
 
 NOTE: Make sure that you have completed the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial.
 
-In this tutorial, we will setup a user level systemd unit for an unprivileged user. There are times when it's helpful to launch a user-level https://www.freedesktop.org/software/systemd/man/systemd.unit.html[systemd unit] without having to log in. For example, you may wish to launch a container that provides a network service or run an HPC job. For this setup, we will add the following to a Fedora CoreOS config:
+In this tutorial, we will setup a user level systemd unit for an unprivileged user. There are times when it's helpful to launch a user-level https://www.freedesktop.org/software/systemd/man/systemd.unit.html[systemd unit] without having to log in. For example, you may wish to launch a container that provides a network service or run an HPC job. For this setup, we will add the following to a Butane config:
 
 * A user level systemd unit: `/home/sleeper/.config/systemd/user/linger-example.service`.
 * Enable it as a user level systemd service.
@@ -44,7 +44,7 @@ storage:
         name: sleeper
 ----
 
-System services can be directly enabled in FCC but user level services have to be manually enabled for now:
+System services can be directly enabled in Butane configs but user level services have to be manually enabled for now:
 
 [source,yaml]
 ----
@@ -80,9 +80,9 @@ storage:
       mode: 0644
 ----
 
-== Writing the Fedora CoreOS config and converting to Ignition
+== Writing the Butane config and converting to Ignition
 
-The final Fedora CoreOS config, stored in `fcct-user.yaml`, will be:
+The final Butane config, stored in `user.bu`, will be:
 
 [source,yaml]
 ----
@@ -133,7 +133,7 @@ This config can be converted to Ignition:
 
 [source,bash]
 ----
-fcct --pretty --strict fcct-user.yaml --output user.ign
+butane --pretty --strict user.bu --output user.ign
 ----
 
 == Testing

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -13,6 +13,8 @@ In this example, we will launch a systemd service for the user `sleeper`. First,
 
 [source,yaml]
 ----
+variant: fcos
+version: 1.3.0
 passwd:
   users:
     - name: sleeper
@@ -22,6 +24,8 @@ This will also create the home directory for the `sleeper` user. Then we can add
 
 [source,yaml]
 ----
+variant: fcos
+version: 1.3.0
 storage:
   files:
     - path: /home/sleeper/.config/systemd/user/linger-example.service
@@ -44,6 +48,8 @@ System services can be directly enabled in FCC but user level services have to b
 
 [source,yaml]
 ----
+variant: fcos
+version: 1.3.0
 storage:
   directories:
     - path: /home/sleeper/.config/systemd/user/default.target.wants
@@ -66,6 +72,8 @@ And finally we setup lingering for the systemd user level instance so that it ge
 
 [source,yaml]
 ----
+variant: fcos
+version: 1.3.0
 storage:
   files:
     - path: /var/lib/systemd/linger/sleeper


### PR DESCRIPTION
The Butane download instructions contain dangling links to upstream release artifacts, which should become valid mid next week, and to the Fedora `butane` package, which might take a week and a half.  I'm half-inclined not to hold this until then, since the PR is pretty intrusive; thoughts?