### PR TITLE
workflows: run check.py as root to avoid Podman bug

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Run validator
-        run: ./check.py -v
+        run: sudo ./check.py -v


### PR DESCRIPTION
Podman in GitHub's Ubuntu 20.04 20210419.1 image throws overlayfs mount/umount failures when run as non-root.

https://github.com/actions/virtual-environments/issues/3229

I'll file a revert PR after this lands.