### PR TITLE
Revert "workflows: run check.py as root to avoid Podman bug"

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
       - name: Run validator
-        run: sudo ./check.py -v
+        run: ./check.py -v


### PR DESCRIPTION
Switch back to running `check.py` as non-root.  We can land this after https://github.com/actions/virtual-environments/issues/3229 is fixed upstream and deployed (i.e., when CI for this PR is green).

This reverts commit 2bdf638d4d0db9f82f0849390347cce622d87a50.