### PR TITLE
live-booting-ipxe: add initrd= karg for UEFI

### DIFF
--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -23,7 +23,7 @@ The example below shows how to load those directly from Fedora infrastructure. F
 #!ipxe
 
 set STREAM stable
-set VERSION 32.20200726.3.1
+set VERSION 33.20210328.3.0
 set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds/${VERSION}/x86_64

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -28,8 +28,8 @@ set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/${STREAM}/builds/${VERSION}/x86_64
 
-kernel ${BASEURL}/fedora-coreos-${VERSION}-live-kernel-x86_64 coreos.live.rootfs_url=${BASEURL}/fedora-coreos-${VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=${CONFIGURL} systemd.unified_cgroup_hierarchy=0
-initrd ${BASEURL}/fedora-coreos-${VERSION}-live-initramfs.x86_64.img
+kernel ${BASEURL}/fedora-coreos-${VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=${BASEURL}/fedora-coreos-${VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=${CONFIGURL} systemd.unified_cgroup_hierarchy=0
+initrd --name main ${BASEURL}/fedora-coreos-${VERSION}-live-initramfs.x86_64.img
 
 boot
 ----


### PR DESCRIPTION
With iPXE on UEFI, the `initrd` _directive_ specifies where to fetch the initrd image, and the `initrd` _kernel argument_ tells the kernel where to find that image after iPXE has written it into the UEFI virtual filesystem.  The `initrd=` argument isn't needed on BIOS but is harmless there.

Fixes: #233
See also: https://ipxe.org/appnote/debian_preseed