### PR TITLE
Rename master branch to main; fix links to upstream docs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,9 +3,9 @@ name: Checks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   butane:

--- a/modules/ROOT/pages/auto-updates.adoc
+++ b/modules/ROOT/pages/auto-updates.adoc
@@ -10,7 +10,7 @@ By default, the OS performs continual auto-updates via two components:
 == Wariness to updates
 
 The local Zincati agent periodically checks with a remote service to see when updates are available.
-A custom "rollout wariness" value (see https://github.com/coreos/zincati/blob/master/docs/usage/auto-updates.md#phased-rollouts-client-wariness-canaries[documentation]) can be provided to let the server know how eager, or how risk-averse, the node is to receiving updates.
+A custom "rollout wariness" value (see https://coreos.github.io/zincati/usage/auto-updates/#phased-rollouts-client-wariness-canaries[documentation]) can be provided to let the server know how eager, or how risk-averse, the node is to receiving updates.
 
 The `rollout_wariness` parameter can be set to a floating point value between `0.0` (most eager) and `1.0` (most conservative).
 In order to receive updates very early in the phased rollout cycle, a node can be configured with a low value (e.g. `0.001`).
@@ -62,6 +62,6 @@ storage:
           start_time = "22:30"
           length_minutes = 60
 ----
-For further details on updates finalization, check the https://github.com/coreos/zincati/blob/master/docs/usage/updates-strategy.md[Zincati documentation].
+For further details on updates finalization, check the https://coreos.github.io/zincati/usage/updates-strategy/[Zincati documentation].
 
 include::manual-rollbacks.adoc[leveloffset=1]

--- a/modules/ROOT/pages/debugging-with-toolbox.adoc
+++ b/modules/ROOT/pages/debugging-with-toolbox.adoc
@@ -65,4 +65,4 @@ toolbox rm --force fedora-toolbox-32
 
 NOTE: The toolbox utility allows you to create toolboxes with your custom
 images. You can find more details in the
-https://github.com/containers/toolbox/tree/master/doc[toolbox manpages].
+https://github.com/containers/toolbox/tree/main/doc[toolbox manpages].

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -285,7 +285,7 @@ Additionally, the different formats (YAML for Butane, JSON for Ignition) help to
 
 == What is the format of the version number?
 
-This is covered in detail in the https://github.com/coreos/fedora-coreos-tracker/blob/master/Design.md#version-numbers[design docs].
+This is covered in detail in the https://github.com/coreos/fedora-coreos-tracker/blob/main/Design.md#version-numbers[design docs].
 
 The summary is that Fedora CoreOS uses the format `X.Y.Z.A`
 

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -24,19 +24,19 @@ The following changes have been made to the installation process:
 * FCOS does not have a recommended mechanism to select the version of `docker`.
 * Network configuration is now handled by NetworkManager instead of `systemd-networkd`.
 * For time synchronization, use https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/servers/Configuring_NTP_Using_the_chrony_Suite/[`chronyd`] rather than `ntpd` or `systemd-timesyncd`.
-* Automatic updates are now coordinated by Zincati, as described in the https://github.com/coreos/zincati/blob/master/docs/usage/auto-updates.md[Zincati documentation]. The rollback mechanism (via grub) is now provided by https://github.com/coreos/rpm-ostree/blob/master/README.md[`rpm-ostree`].
-* The functionality of the reboot manager (`locksmith`) is rolled into https://github.com/coreos/zincati/blob/master/README.md[Zincati].
+* Automatic updates are now coordinated by Zincati, as described in the https://coreos.github.io/zincati/usage/auto-updates/[Zincati documentation]. The rollback mechanism (via grub) is now provided by https://coreos.github.io/rpm-ostree/[`rpm-ostree`].
+* The functionality of the reboot manager (`locksmith`) is rolled into https://coreos.github.io/zincati/[Zincati].
 * The `update-ssh-keys` tool is not provided on FCOS. sshd uses a xref:authentication.adoc#ssh-key-locations[helper program] to read key files directly out of `~/.ssh/authorized_keys.d`.
 
 == Configuration changes
 
 When writing Butane configs, note the following changes:
 
-* `coreos-metadata` is now https://github.com/coreos/afterburn/blob/master/README.md[Afterburn]. The prefix of the metadata variable names has changed from `COREOS_` to `AFTERBURN_`, and the following platform names have changed:
+* `coreos-metadata` is now https://coreos.github.io/afterburn/[Afterburn]. The prefix of the metadata variable names has changed from `COREOS_` to `AFTERBURN_`, and the following platform names have changed:
 ** `EC2` is now `AWS`
 ** `GCE` is now `GCP`
 +
-For more info, see the https://github.com/coreos/afterburn/blob/master/docs/usage/attributes.md[Afterburn documentation].
+For more info, see the https://coreos.github.io/afterburn/usage/attributes/[Afterburn documentation].
 
 * By default, FCOS does not allow password logins via SSH. We recommend xref:authentication.adoc#using-an-ssh-key[configuring SSH keys] instead. If needed, you can xref:authentication.adoc#enabling-ssh-password-authentication[enable SSH password authentication].
 * Because `usermod` is not yet fully-functional on FCOS, there is a `docker` group in the `/etc/group` file. This is a stop-gap measure to facilitate a smooth transition to FCOS. The team is working on a more functional `usermod`, at which time the `docker` group will no longer be included by default. See the https://github.com/coreos/fedora-coreos-tracker/issues/2[docker group issue].

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -46,7 +46,7 @@ For more info, see the https://coreos.github.io/afterburn/usage/attributes/[Afte
 == Operator notes
 
 * FCOS provides https://fedoramagazine.org/fedora-coreos-out-of-preview/[best-effort stability], and may occasionally include regressions or breaking changes for some use cases or workloads.
-* CL had three release channels: `alpha`, `beta`, and `stable`. The FCOS production https://github.com/coreos/fedora-coreos-tracker/blob/master/Design.md#release-streams[release streams] are `next`, `testing`, and `stable`, with somewhat different semantics.
+* CL had three release channels: `alpha`, `beta`, and `stable`. The FCOS production https://github.com/coreos/fedora-coreos-tracker/blob/main/Design.md#release-streams[release streams] are `next`, `testing`, and `stable`, with somewhat different semantics.
 * In general, SELinux confinement should work the same as in Fedora.
 * To deploy an Ignition config as part of a PXE image (a "custom OEM" in CL terminology), follow the https://coreos.com/os/docs/latest/booting-with-pxe.html#adding-a-custom-oem[same process] as in CL, but place the `config.ign` file in the root of the archive.
 * In CL, metrics/telemetry data was collected by the update mechanism. In FCOS, the data is collected (without unique identifiers) by https://github.com/coreos/fedora-coreos-pinger[`fedora-coreos-pinger`].
@@ -59,7 +59,7 @@ enabled = false
 ----
 * Cloud CLI clients are not included in FCOS. There is an initiative to create a "tools" container to run on FCOS.
 * When opening an existing file in a sticky directory, the behavior differs from CL. See https://github.com/systemd/systemd/commit/2732587540035227fe59e4b64b60127352611b35[the relevant systemd commit].
-* CL left Simultaneous Multi-Threading (SMT) enabled but advised users to turn it off if their systems were vulnerable to certain issues such as https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html[L1TF] or https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html[MDS]. By default, FCOS https://github.com/coreos/fedora-coreos-tracker/blob/master/Design.md#automatically-disable-smt-when-needed-to-address-vulnerabilities[automatically disables SMT] for vulnerable systems.
+* CL left Simultaneous Multi-Threading (SMT) enabled but advised users to turn it off if their systems were vulnerable to certain issues such as https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/l1tf.html[L1TF] or https://www.kernel.org/doc/html/latest/admin-guide/hw-vuln/mds.html[MDS]. By default, FCOS https://github.com/coreos/fedora-coreos-tracker/blob/main/Design.md#automatically-disable-smt-when-needed-to-address-vulnerabilities[automatically disables SMT] for vulnerable systems.
 * In general, `docker` uses the default configuration from Fedora, which is different under many aspects. Notably the logging driver is set to `journald` and live-restore is enabled.
 
 == Implementation notes

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -127,4 +127,4 @@ govc vm.power -on "${VM_NAME}"
 
 The full syntax of the `ip=` parameter is documented in https://www.man7.org/linux/man-pages/man7/dracut.cmdline.7.html[Dracut manpages].
 
-For further information on first-boot networking, see https://github.com/coreos/afterburn/blob/master/docs/usage/initrd-network-cmdline.md[Afterburn documentation].
+For further information on first-boot networking, see https://coreos.github.io/afterburn/usage/initrd-network-cmdline/[Afterburn documentation].

--- a/modules/ROOT/pages/running-containers.adoc
+++ b/modules/ROOT/pages/running-containers.adoc
@@ -69,4 +69,4 @@ systemd:
 ----
 
 === For more information
-See the https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/container.md#docker[etcd documentation] for more information on running etcd in containers and how to set up multi-node etcd.
+See the https://etcd.io/docs/latest/op-guide/container/#docker[etcd documentation] for more information on running etcd in containers and how to set up multi-node etcd.

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -264,7 +264,7 @@ storage:
       with_mount_unit: true
 ----
 
-The root filesystem can also be moved to LUKS. In the case of the root filesystem the LUKS device must be backed by https://github.com/coreos/ignition/blob/master/docs/operator-notes.md#clevis-based-devices[clevis]. There is simplified Butane config syntax for encrypting the root filesystem; for example:
+The root filesystem can also be moved to LUKS. In the case of the root filesystem the LUKS device must be backed by https://coreos.github.io/ignition/operator-notes/#clevis-based-devices[clevis]. There is simplified Butane config syntax for encrypting the root filesystem; for example:
 
 .Moving the root filesystem to LUKS
 [source,yaml]

--- a/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
@@ -2,7 +2,7 @@
 
 In Fedora 33 some editions https://www.fedoraproject.org/wiki/Releases/33/ChangeSet#swap_on_zram[enabled swap on ZRAM by default]. Fedora CoreOS currently has the `zram-generator` included but no configuration in place to enable swap on ZRAM by default. In order to configure swap on ZRAM you can lay down a configuration file via Ignition that will tell the zram generator to set up swap on top of a zram device. 
 
-The documentation for the config file format lives in the https://github.com/systemd/zram-generator/blob/master/man/zram-generator.conf.md[upstream documentation] along with a comprehensive https://github.com/systemd/zram-generator/blob/master/zram-generator.conf.example[example]. The most basic form of a configuration file that will set up a `zram0` device for swap is:
+The documentation for the config file format lives in the https://github.com/systemd/zram-generator/blob/main/man/zram-generator.conf.md[upstream documentation] along with a comprehensive https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example[example]. The most basic form of a configuration file that will set up a `zram0` device for swap is:
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -84,7 +84,7 @@ On certain platforms Afterburn will inject networking configuration, either conf
 
 Currently this is only utilized on VMWare. The implementation there allows for users to specify networking configuration in the form of dracut networking arguments without having to stop the boot of the machine and manually inject those arguments themselves.
 
-See https://github.com/coreos/afterburn/blob/master/docs/usage/initrd-network-cmdline.md[the Afterburn documentation] for more information.
+See https://coreos.github.io/afterburn/usage/initrd-network-cmdline/[the Afterburn documentation] for more information.
 
 ==== via Ignition
 

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -263,4 +263,4 @@ virsh undefine --remove-all-storage fcos
 
 == Conclusion
 
-In these tutorials we have learned a little bit about Fedora CoreOS. We have learned how it is delivered as a pre-created disk image, how it is provisioned in an automated fashion via Ignition, and also how automated updates are configured and achieved via Zincati and rpm-ostree. The next step is to try out Fedora CoreOS for your own use cases and https://github.com/coreos/fedora-coreos-tracker/blob/master/README.md#communication-channels-for-fedora-coreos[join the community]!
+In these tutorials we have learned a little bit about Fedora CoreOS. We have learned how it is delivered as a pre-created disk image, how it is provisioned in an automated fashion via Ignition, and also how automated updates are configured and achieved via Zincati and rpm-ostree. The next step is to try out Fedora CoreOS for your own use cases and https://github.com/coreos/fedora-coreos-tracker/blob/main/README.md#communication-channels-for-fedora-coreos[join the community]!


### PR DESCRIPTION
We can't change the version `master` to `main` in `antora.yml` because `master` is special-cased to produce non-versioned URLs.

Hold until cutover.