### PR TITLE
Correct permissions of the user systemd unit

### DIFF
--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -29,7 +29,7 @@ version: 1.3.0
 storage:
   files:
     - path: /home/sleeper/.config/systemd/user/linger-example.service
-      mode: 0744
+      mode: 0644
       contents:
         inline: |
           [Unit]


### PR DESCRIPTION
The permissions for the user systemd unit file should be 0644.