### PR TITLE
kernel-args: drop instructions for upgrading to cgroups v2

### DIFF
--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -80,52 +80,9 @@ NOTE: The Ignition `kernelArguments` section requires Butane spec version `1.4.0
 
 NOTE:  The `After=systemd-machine-id-commit.service` directive is important in the following systemd service examples to avoid some subtle issues. Similarly, any `ConditionFirstBoot=true` services should use `Before=first-boot-complete.target systemd-machine-id-commit.service`. See https://github.com/systemd/systemd/blob/3045c416e1cbbd8ab40577790522217fd1b9cb3b/man/systemd.unit.xml#L1315[the systemd documentation] for more details.
 
-=== Example: Moving to cgroups v2
-
-cgroups v1 will be the default in the Fedora CoreOS `stable` stream until June 15, 2021. Here's an example `kernelArguments` section which removes the `systemd.unified_cgroup_hierarchy=0` kernel argument so that the machine switches to cgroups v2:
-
-[source,yaml]
-----
-variant: fcos
-version: 1.4.0-experimental
-kernel_arguments:
-  should_not_exist:
-    - systemd.unified_cgroup_hierarchy=0
-----
-
-Alternatively, here's an example systemd unit that does the same:
-
-[source,yaml]
-----
-variant: fcos
-version: 1.3.0
-systemd:
-  units:
-    - name: cgroups-v2-karg.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Switch To cgroups v2
-        # We run after `systemd-machine-id-commit.service` to ensure that
-        # `ConditionFirstBoot=true` services won't rerun on the next boot.
-        After=systemd-machine-id-commit.service
-        ConditionKernelCommandLine=systemd.unified_cgroup_hierarchy
-        ConditionPathExists=!/var/lib/cgroups-v2-karg.stamp
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/bin/rpm-ostree kargs --delete=systemd.unified_cgroup_hierarchy
-        ExecStart=/bin/touch /var/lib/cgroups-v2-karg.stamp
-        ExecStart=/bin/systemctl --no-block reboot
-
-        [Install]
-        WantedBy=multi-user.target
-----
-
 === Example: Staying on cgroups v1
 
-Starting from June 1, 2021, cgroups v2 is the default on Fedora CoreOS on the `next` and `testing` streams. Here's an example `kernelArguments` section which adds the `systemd.unified_cgroup_hierarchy=0` kernel argument so that the machine keeps using cgroups v1:
+Starting from June 2021, cgroups v2 is the default on new installations of Fedora CoreOS. Here's an example `kernelArguments` section which adds the `systemd.unified_cgroup_hierarchy=0` kernel argument so that the machine keeps using cgroups v1:
 
 [source,yaml]
 ----


### PR DESCRIPTION
All channels now default to cgroups v2.  Delete upgrade instructions and update wording of downgrade instructions.

Followup to #298.