### PR TITLE
Stabilize Butane spec 1.4.0; drop instructions for `rpm-ostree kargs` systemd unit

### DIFF
--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -74,9 +74,7 @@ $ sudo rpm-ostree kargs --editor
 
 == Modifying Kernel Arguments via Ignition
 
-There are two ways to modify kernel arguments via Ignition. The current Ignition config spec supports specifying kernel arguments via the `kernelArguments` section. It is also possible to use Ignition to script a systemd service which runs `rpm-ostree kargs` and then triggers a reboot.
-
-NOTE:  The `After=systemd-machine-id-commit.service` directive is important in the following systemd service examples to avoid some subtle issues. Similarly, any `ConditionFirstBoot=true` services should use `Before=first-boot-complete.target systemd-machine-id-commit.service`. See https://github.com/systemd/systemd/blob/3045c416e1cbbd8ab40577790522217fd1b9cb3b/man/systemd.unit.xml#L1315[the systemd documentation] for more details.
+You can specify kernel arguments in a Butane config using the `kernel_arguments` section.
 
 === Example: Staying on cgroups v1
 
@@ -89,36 +87,6 @@ version: 1.4.0
 kernel_arguments:
   should_exist:
     - systemd.unified_cgroup_hierarchy=0
-----
-
-Alternatively, here's an example systemd unit that does the same:
-
-[source,yaml]
-----
-variant: fcos
-version: 1.3.0
-systemd:
-  units:
-    - name: cgroups-v1-karg.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Switch to cgroups v1
-        # We run after `systemd-machine-id-commit.service` to ensure that
-        # `ConditionFirstBoot=true` services won't rerun on the next boot.
-        After=systemd-machine-id-commit.service
-        ConditionKernelCommandLine=!systemd.unified_cgroup_hierarchy
-        ConditionPathExists=!/var/lib/cgroups-v1-karg.stamp
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/bin/rpm-ostree kargs --append=systemd.unified_cgroup_hierarchy=0
-        ExecStart=/bin/touch /var/lib/cgroups-v1-karg.stamp
-        ExecStart=/bin/systemctl --no-block reboot
-
-        [Install]
-        WantedBy=multi-user.target
 ----
 
 === Example: Disabling all CPU vulnerability mitigations
@@ -134,34 +102,4 @@ kernel_arguments:
     - mitigations=off
   should_not_exist:
     - mitigations=auto,nosmt
-----
-
-Alternatively, here's an example systemd unit that does the same:
-
-[source,yaml]
-----
-variant: fcos
-version: 1.3.0
-systemd:
-  units:
-    - name: cpu-mitigations-karg.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Disable all CPU vulnerability mitigations
-        # We run after `systemd-machine-id-commit.service` to ensure that
-        # `ConditionFirstBoot=true` services won't rerun on the next boot.
-        After=systemd-machine-id-commit.service
-        ConditionKernelCommandLine=!mitigations=off
-        ConditionPathExists=!/var/lib/cpu-mitigations-karg.stamp
-
-        [Service]
-        Type=oneshot
-        RemainAfterExit=yes
-        ExecStart=/bin/rpm-ostree kargs --replace=mitigations=auto,nosmt=off
-        ExecStart=/bin/touch /var/lib/cpu-mitigations-karg.stamp
-        ExecStart=/bin/systemctl --no-block reboot
-
-        [Install]
-        WantedBy=multi-user.target
 ----

--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -74,9 +74,7 @@ $ sudo rpm-ostree kargs --editor
 
 == Modifying Kernel Arguments via Ignition
 
-There are two ways to modify kernel arguments via Ignition. The current Ignition experimental config spec supports specifying kernel arguments via the `kernelArguments` section. It is also possible to use Ignition to script a systemd service which runs `rpm-ostree kargs` and then triggers a reboot.
-
-NOTE: The Ignition `kernelArguments` section requires Butane spec version `1.4.0-experimental`.  After spec 1.4.0 is stabilized, version `1.4.0-experimental` will no longer be accepted by Butane, so Butane configs will need to be updated to replace `1.4.0-experimental` with `1.4.0`.  In addition, the corresponding Ignition config version will no longer be accepted by Ignition, so Ignition configs will need to be regenerated with a new version of Butane.
+There are two ways to modify kernel arguments via Ignition. The current Ignition config spec supports specifying kernel arguments via the `kernelArguments` section. It is also possible to use Ignition to script a systemd service which runs `rpm-ostree kargs` and then triggers a reboot.
 
 NOTE:  The `After=systemd-machine-id-commit.service` directive is important in the following systemd service examples to avoid some subtle issues. Similarly, any `ConditionFirstBoot=true` services should use `Before=first-boot-complete.target systemd-machine-id-commit.service`. See https://github.com/systemd/systemd/blob/3045c416e1cbbd8ab40577790522217fd1b9cb3b/man/systemd.unit.xml#L1315[the systemd documentation] for more details.
 
@@ -87,7 +85,7 @@ Starting from June 2021, cgroups v2 is the default on new installations of Fedor
 [source,yaml]
 ----
 variant: fcos
-version: 1.4.0-experimental
+version: 1.4.0
 kernel_arguments:
   should_exist:
     - systemd.unified_cgroup_hierarchy=0
@@ -130,7 +128,7 @@ Here's an example `kernelArguments` section which switches `mitigations=auto,nos
 [source,yaml]
 ----
 variant: fcos
-version: 1.4.0-experimental
+version: 1.4.0
 kernel_arguments:
   should_exist:
     - mitigations=off

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -335,13 +335,11 @@ storage:
 
 This example creates a swap partition spanning all of the `sdb` device, creates a swap area on it, and creates a systemd swap unit so the swap area is enabled on boot.
 
-NOTE: Using `with_mount_unit: true` with `format: swap` requires Butane spec version `1.4.0-experimental`.  After spec 1.4.0 is stabilized, version `1.4.0-experimental` will no longer be accepted by Butane, so Butane configs will need to be updated to replace `1.4.0-experimental` with `1.4.0`.  In addition, the corresponding Ignition config version will no longer be accepted by Ignition, so Ignition configs will need to be regenerated with a new version of Butane.
-
 .Configuring a swap partition on a second disk
 [source,yaml]
 ----
 variant: fcos
-version: 1.4.0-experimental
+version: 1.4.0
 storage:
   disks:
     - device: /dev/sdb


### PR DESCRIPTION
Now that Ignition kargs support is stabilized, we can drop the alternate instructions for running `rpm-ostree kargs` via a systemd unit.

Hold until Ignition 2.11.0 reaches FCOS `stable` and Butane `fcos` spec 1.4.0 is stabilized.