### PR TITLE
Add Windows instructions for getting Butane

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -130,6 +130,23 @@ curl https://getfedora.org/static/fedora.gpg | gpg --import
 gpg --verify butane-x86_64-apple-darwin.asc
 ----
 
+==== Windows
+To use the Butane binary on Windows, follow these steps:
+
+. If you have not already done so, download the https://getfedora.org/static/fedora.gpg[Fedora signing keys] and import them:
++
+[source,powershell]
+----
+Invoke-RestMethod -Uri https://getfedora.org/static/fedora.gpg | gpg --import
+----
+. Download the latest version of Butane and the detached signature from the https://github.com/coreos/butane/releases[releases page].
+. Verify it with gpg:
++
+[source,powershell]
+----
+gpg --verify butane-x86_64-pc-windows-gnu.exe.asc
+----
+
 == A simple example
 
 Create a basic Ignition config that modifies the default Fedora CoreOS user `core` to allow this user to log in with an SSH key.


### PR DESCRIPTION
Contains instructions for standalone binary installation on Windows. I presume that the user installs GPG, e.g. via Git for Windows, on their own for signature verification and, hence, don't provide additional instructions for that.

I would've added instructions for e.g. [scoop](https://scoop.sh) as well but my pull request (lukesampson/scoop-extras/pull/6194) is currently in limbo 😞.