### PR TITLE
Fixes various minor issues

### DIFF
--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -6,7 +6,7 @@ However, in some cases it is necessary to add software to the base OS itself. Fo
 
 To do this, you can use https://coreos.github.io/rpm-ostree/[`rpm-ostree install`]. Consider these packages as "extensions": they extend the functionality of the base OS rather than e.g. providing runtimes for user applications. That said, there are no restrictions on which packages one can actually install. By default, packages are downloaded from the https://docs.fedoraproject.org/en-US/quick-docs/repositories/[Fedora repositories].
 
-To start the layering of a package, you need to write a systemd unit that executes the `rpm-ostree` command to install the wanted package(s). 
+To start the layering of a package, you need to write a systemd unit that executes the `rpm-ostree` command to install the wanted package(s).
 Changes are applied to a new deployment and a reboot is necessary for those to take effect.
 
 == Example: Layering nano and setting it as the default editor
@@ -37,13 +37,13 @@ systemd:
         # We run before `zincati.service` to avoid conflicting rpm-ostree
         # transactions.
         Before=zincati.service
-        ConditionPathExists=!/var/lib/rpm-ostree-install-nano.stamp
+        ConditionPathExists=!/var/lib/%N.stamp
 
         [Service]
         Type=oneshot
         RemainAfterExit=yes
         ExecStart=/usr/bin/rpm-ostree install --allow-inactive nano
-        ExecStart=/bin/touch /var/lib/rpm-ostree-install-nano.stamp
+        ExecStart=/bin/touch /var/lib/%N.stamp
         ExecStart=/bin/systemctl --no-block reboot
 
         [Install]

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -190,7 +190,7 @@ TIP: YAML files must have consistent indentation. Although Butane checks for syn
 +
 [source,bash]
 ----
-butane --pretty --strict < example.bu > example.ign
+butane --pretty --strict example.bu > example.ign
 ----
 +
 . Use the `example.ign` file to xref:getting-started.adoc[boot Fedora CoreOS].

--- a/modules/ROOT/pages/provisioning-aliyun.adoc
+++ b/modules/ROOT/pages/provisioning-aliyun.adoc
@@ -6,6 +6,8 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Alibaba Clou
 
 Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
+
 You also need to have access to an Alibaba Cloud account and https://www.alibabacloud.com/help/doc-detail/31884.htm?spm=a2c63.p38356.879954.10.3d1264baRYHfmB#task-njz-hf4-tdb[activated Object Storage Service (OSS)].
 The examples below use the https://www.alibabacloud.com/help/product/29991.htm[Alibaba Cloud CLI] and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -4,7 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on the Amaz
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to an AWS account. The examples below use the https://aws.amazon.com/cli/[aws] command-line tool, which must be separately installed and configured beforehand.
 

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -4,7 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Azure. Fedor
 
 == Prerequisites
 
-Before provisioning a FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to an Azure subscription. The examples below use the https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest[Azure CLI].
 

--- a/modules/ROOT/pages/provisioning-digitalocean.adoc
+++ b/modules/ROOT/pages/provisioning-digitalocean.adoc
@@ -4,7 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on DigitalOcean
 
 == Prerequisites
 
-Before provisioning a FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to a DigitalOcean account. The examples below use the https://github.com/digitalocean/doctl[doctl] command-line tool.
 

--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -4,7 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on https://
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you may want to have at hand an Ignition configuration file containing your customizations. If you need one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to an Exoscale account. https://portal.exoscale.com/register[Register] if you don't have one.
 

--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -4,7 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on Google C
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to a GCP account. The examples below use the https://cloud.google.com/sdk/gcloud[gcloud] command-line tool, which must be separately installed and configured beforehand.
 

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -4,10 +4,11 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances in IBM Clou
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
-You also need to have access to an https://cloud.ibm.com/login[IBM Cloud account]. The examples below use the https://cloud.ibm.com/docs/cli?topic=cli-getting-started[`ibmcloud`] command-line tool, which must be separately installed and configured beforehand. There are also several pieces that need to be in place first, like a VPC, SSH keys, networks, permissions, etc. Unfortunately, this guide is not a comprehensive IBM Cloud guide. If you are new to IBM Cloud please familiarize yourself using https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started[the documentation for VPC Gen2] first.
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
+You also need to have access to an https://cloud.ibm.com/login[IBM Cloud account]. The examples below use the https://cloud.ibm.com/docs/cli?topic=cli-getting-started[`ibmcloud`] command-line tool, which must be separately installed and configured beforehand.
 Regarding the `ibmcloud` CLI, it is worth noting that it is supported to run the CLI https://cloud.ibm.com/docs/cli?topic=cli-using-idt-from-docker[via a container]. You'll need both the `cloud-object-storage` and `infrastructure-service` plugins installed. This can be done with:
 
  * `ibmcloud plugin install cloud-object-storage`
@@ -21,6 +22,8 @@ After you've logged in using `ibmcloud login` you can set a target region:
 REGION='us-east' # run `ibmcloud regions` to view options
 ibmcloud target -r $REGION
 ----
+
+There are also several other pieces that need to be in place, like a VPC, SSH keys, networks, permissions, etc. Unfortunately, this guide is not a comprehensive IBM Cloud guide. If you are new to IBM Cloud please familiarize yourself using https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started[the documentation for VPC Gen2] first.
 
 === Creating an Image
 
@@ -41,7 +44,7 @@ BUCKET='my-unique-bucket'
 ibmcloud resource service-instance-create "${BUCKET}-service-instance" cloud-object-storage standard global
 
 SERVICE_INSTANCE_ID='25df0db0-89a4-4cb8-900f-ed8b44259f80' # from just created service account
-ibmcloud iam authorization-policy-create is --source-resource-type image cloud-object-storage Reader --target-service-instance-id $SERVICE_INSTANCE_ID 
+ibmcloud iam authorization-policy-create is --source-resource-type image cloud-object-storage Reader --target-service-instance-id $SERVICE_INSTANCE_ID
 ----
 
 .Upload the fetched image file to IBM Cloud Object Storage.

--- a/modules/ROOT/pages/provisioning-libvirt.adoc
+++ b/modules/ROOT/pages/provisioning-libvirt.adoc
@@ -4,7 +4,7 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on a https:
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
 You also need to have access to an host machine with `libvirt`. The examples below use the `virt-install` command-line tool, which must be separately installed beforehand.
 

--- a/modules/ROOT/pages/provisioning-openstack.adoc
+++ b/modules/ROOT/pages/provisioning-openstack.adoc
@@ -7,9 +7,9 @@ The steps below were tested against the OpenStack Victoria release.
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file
-containing your customizations. If you do not have one, see
-xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to an OpenStack environment and a functioning
 https://docs.openstack.org/python-designateclient/latest/user/shell-v2.html[`openstack` CLI].

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -4,7 +4,7 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on a bare h
 
 == Prerequisites
 
-Before provisioning a FCOS instance, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
 You also need to have access to an host machine with https://www.linux-kvm.org/page/Main_Page[KVM] support. The examples below use the `qemu-kvm` command-line tool, which must be separately installed beforehand.
 

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -4,7 +4,7 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on the VMware h
 
 == Prerequisites
 
-Before provisioning a FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
 You also need to have access to a working VMware infrastructure, supporting VMs with at least hardware version 13.
 The examples below use the https://github.com/vmware/govmomi/blob/v0.22.2/govc/README.md[govc] command-line tool for remote vSphere provisioning and the https://code.vmware.com/web/tool/4.4.0/ovf[ovftool] for local Workstation or Fusion provisoning.
@@ -107,7 +107,7 @@ For this reason, on first-boot FCOS instances try to perform network autoconfigu
 If your VMware setup employs static network configuration instead, you can override this automatic DHCP setup with your own custom configuration.
 Custom networking command-line `ip=` parameter can be configured via guestinfo properties as shown below, before booting a VM for the first time.
 
-The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry. 
+The provisioning flow follows the usual steps, plus an additional `guestinfo.afterburn.initrd.network-kargs` entry.
 
 NOTE: if you are using a provisioning method other than `govc`, make sure that the guestinfo attribute is provisioned in the VM's Advanced Configuration Parameters (also known as `ExtraConfig`). Some management tools may default to a vApp Property instead, which does not work in this scenario.
 

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -4,7 +4,11 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Vultr. FCOS 
 
 == Prerequisites
 
-Before provisioning a FCOS machine, you must have an Ignition configuration file that sets SSH authorized keys for the core user. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File]. While the Vultr documentation mentions cloud-init and scripts, FCOS does not support cloud-init or the ability to run scripts from user-data. It accepts only Ignition configuration files.
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
+
+While the Vultr documentation mentions `cloud-init` and scripts, FCOS does not support `cloud-init` or the ability to run scripts from user-data. It accepts only Ignition configuration files.
 
 You also need to have access to a Vultr account. The examples below use the https://github.com/vultr/vultr-cli[vultr-cli] and https://s3tools.org/s3cmd[s3cmd] command-line tools.
 

--- a/modules/ROOT/pages/stream-metadata.adoc
+++ b/modules/ROOT/pages/stream-metadata.adoc
@@ -1,7 +1,7 @@
 
 = Stream metadata
 
-Metadata about Fedora CoreOS is available in a custom JSON format, called "stream metadata".  For maintaining automation, it is expected that you will interact with this stream metadata. 
+Metadata about Fedora CoreOS is available in a custom JSON format, called "stream metadata". For maintaining automation, it is expected that you will interact with this stream metadata.
 
 The format is stable, and intended to be relatively self-documenting.  There is not yet a JSON schema.
 However, in most web browsers, navigating to the URL will render the JSON in an easy-to-read form.
@@ -9,7 +9,7 @@ However, in most web browsers, navigating to the URL will render the JSON in an 
 == Canonical URL
 
 The URL for the `stable` stream is: https://builds.coreos.fedoraproject.org/streams/stable.json
-You can similarly replace `stable` here with other available xref:available-update-streams.adoc[Update Streams].
+You can similarly replace `stable` here with other available xref:update-streams.adoc[Update Streams].
 
 == Using coreos-installer to download
 
@@ -23,8 +23,8 @@ coreos-installer download --decompress -s $STREAM -p openstack -f qcow2.xz
 
 == Using coreos/stream-metadata-go
 
-There is an official [coreos/stream-metadata-go](https://github.com/coreos/stream-metadata-go) library for
-software written in the Go programming language.  The README.md file in that repository contains a link to example code.
+There is an official https://github.com/coreos/stream-metadata-go[coreos/stream-metadata-go] library for
+software written in the Go programming language. The `README.md` file in that repository contains a link to example code.
 
 == Example: Script ec2 CLI
 
@@ -37,4 +37,3 @@ $ echo $AMI
 ami-021238084bf8c95ff
 $ aws ec2 run-instances --region us-west-1 --image-id "${AMI}" ...
 ----
-


### PR DESCRIPTION
- removes unnecessary shell redirect from butane example
- Aligns prerequisite header across all provisioning manuals
- fixes stream metadata page with broken Adoc syntax and references
- Use `%N` (unit name without extension suffix) instead of writing the name multiple times in systemd os-extension unit
- removes some trailing whitespaces