### PR TITLE
Adds instructions for installing butane via Scoop

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -94,6 +94,16 @@ Butane is available as a https://www.macports.org/[MacPorts] package:
 sudo port install butane
 ----
 
+==== Installing via Scoop
+
+Butane is available as a https://scoop.sh[Scoop] package via the https://github.com/lukesampson/scoop-extras[extras]:
+
+[source,powershell]
+----
+scoop bucket add extras
+scoop install butane
+----
+
 === Standalone binary
 
 ==== Linux


### PR DESCRIPTION
As mentioned in #310 there was a pull request over at scoop
(lukesampson/scoop-extras/pull/6194) to add butane as package. The pull request was
approved and merged so here are the usage instructions.