### PR TITLE
aliyun: tweak for using custom Ignition

### DIFF
--- a/modules/ROOT/pages/provisioning-aliyun.adoc
+++ b/modules/ROOT/pages/provisioning-aliyun.adoc
@@ -198,4 +198,4 @@ aliyun ecs DescribeInstanceStatus --InstanceId.1="$INSTANCE_ID" --region="${REGI
 ssh core@"${PUBLIC_IP}"
 ----
 
-You can start a customized instance with your Ignition file by adding the parameter `--UserData=$(cat <Path to your ignition file> | base64)` to the above command that creates a new instance.
+You can start a customized instance with your Ignition file by adding the parameter `--UserData=$(cat <Path to your Ignition config> | base64 -w0)` to the `aliyun ecs CreateInstance` command that creates a new instance.


### PR DESCRIPTION
If you don't remove the wrapping that happens by default when using
`base64` to encode the Ignition config, the `aliyun ecs
CreateInstance` command complains that you have provided too many
arguments.