### PR TITLE
Add example: Merge a remote Ignition and other config to the current config

### DIFF
--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -36,7 +36,7 @@ ignition:
 
 NOTE: The certificate authorities listed here are not automatically added to the host filesystem. They are solely used by Ignition itself when fetching over `https`. If you'd like to also install them on the host filesystem, include them as usual under the `storage.files` array.
 
-In some cases, you need to merge a local configuration and one or several remote ones, you can use the `merge` rather than `replace` in a Butane config.
+In some cases, if you need to merge a local configuration and one or several remote ones, you can use the `merge` rather than `replace` in a Butane config.
 
 .Retrieving a remote Ignition file via HTTP and merging it with the current config
 [source,yaml]

--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -35,3 +35,21 @@ ignition:
 ----
 
 NOTE: The certificate authorities listed here are not automatically added to the host filesystem. They are solely used by Ignition itself when fetching over `https`. If you'd like to also install them on the host filesystem, include them as usual under the `storage.files` array.
+
+.Retrieving a remote Ignition file via HTTP, also add other config to be merged to the current config
+[source,yaml]
+----
+variant: fcos
+version: 1.4.0
+ignition:
+  config:
+    merge:
+      - source: http://example.com/sample.ign
+        verification:
+          hash: sha512-e2bb19fdbc3604f511b13d66f4c675f011a63dd967b97e2fe4f5d50bf6cb224e902182221ba0f9dd87c0bb4abcbd2ab428eb7965aa7f177eb5630e7a1793e2e6
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDHn2eh...          
+----

--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -36,6 +36,8 @@ ignition:
 
 NOTE: The certificate authorities listed here are not automatically added to the host filesystem. They are solely used by Ignition itself when fetching over `https`. If you'd like to also install them on the host filesystem, include them as usual under the `storage.files` array.
 
+In some cases, you need to merge a local configuration and one or several remote ones, you can use the `merge` rather than `replace` in a Butane config.
+
 .Retrieving a remote Ignition file via HTTP and merging it with the current config
 [source,yaml]
 ----

--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -36,7 +36,7 @@ ignition:
 
 NOTE: The certificate authorities listed here are not automatically added to the host filesystem. They are solely used by Ignition itself when fetching over `https`. If you'd like to also install them on the host filesystem, include them as usual under the `storage.files` array.
 
-.Retrieving a remote Ignition file via HTTP, also add other config to be merged to the current config
+.Retrieving a remote Ignition file via HTTP and merging it with the current config
 [source,yaml]
 ----
 variant: fcos


### PR DESCRIPTION
Add an example:
Retrieving a remote Ignition file via HTTP, also add other config to be merged to the current config

This is useful when using kola to run test with a remote Ignition file via HTTP,  in this case, we need to use `merge` instead of `replace`

Thanks @lucab for pointing this out