### PR TITLE
provisioning-vmware: fix explanation of govc argument limit

### DIFF
--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -43,7 +43,7 @@ An alternative to plain `base64` encoding is `gzip+base64` as described in the h
 [source, bash]
 ----
 CONFIG_ENCODING='gzip+base64'
-CONFIG_ENCODED=$(cat example.ign | gzip | base64 -w0 -)
+CONFIG_ENCODED=$(cat example.ign | gzip -9 | base64 -w0 -)
 ----
 
 == Booting a new VM on Workstation or Fusion


### PR DESCRIPTION
The relevant limit is OS-dependent and isn't always `ARG_MAX`.  On Linux it's `MAX_ARG_STRLEN`, and on Windows, `cmd.exe` and PowerShell impose lower limits than the kernel does.

While we're here, switch `gzip` to use max compression.

cc @Okeanos 