### PR TITLE
provisioning/aws: update AWS docs to be less open ended

### DIFF
--- a/modules/ROOT/pages/getting-started-aws.adoc
+++ b/modules/ROOT/pages/getting-started-aws.adoc
@@ -1,24 +1,62 @@
 :page-partial:
 
-New AWS instances can be directly created and booted from public FCOS images.  You can find the latest AMI for each region from the xref:getting-started.adoc[Update Streams], which is also visualized in the https://getfedora.org/coreos/download/[download page].
+New AWS instances can be directly created from the public FCOS images.  You can find the latest AMI for each region from the https://getfedora.org/coreos/download/[download page].
 
-If you are only interested in exploring FCOS without further customization, you can directly use a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered SSH key-pair] for the default `core` user.
+If you are only interested in exploring FCOS without further customization, you can use a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered SSH key-pair] for the default `core` user.
 
-In order to test out FCOS this way, simply select the relevant SSH key-pair via `--key-name` when launching the new instance:
+To test out FCOS this way you'll need to run the `aws ec2 run-instances` command and provide some information to get the instance up and running. The following is an example command you can use:
 
 .Launching a new instance
 [source, bash]
 ----
-SSH_KEY_NAME="my-key"
-aws ec2 run-instances <other options> --image-id <ami> --key-name "${SSH_KEY_NAME}"
+NAME='instance1'
+SSHKEY='my-key'     # the name of your SSH key: `aws ec2 describe-key-pairs`
+IMAGE='ami-xxx'     # the AMI ID found on the download page
+DISK='20'           # the size of the hard disk
+REGION='us-east-1'  # the target region
+TYPE='m5.large'     # the instance type
+SUBNET='subnet-xxx' # the subnet: `aws ec2 describe-subnets`
+SECURITY_GROUPS='sg-xx' # the security group `aws ec2 describe-security-groups`
+aws ec2 run-instances                     \
+    --region $REGION                      \
+    --image-id $IMAGE                     \
+    --instance-type $TYPE                 \
+    --key-name $SSHKEY                    \
+    --subnet-id $SUBNET                   \
+    --security-group-ids $SECURITY_GROUPS \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${NAME}}]" \
+    --block-device-mappings "VirtualName=/dev/xvda,DeviceName=/dev/xvda,Ebs={VolumeSize=${DISK}}"
 ----
 
-In order to launch a customized FCOS instance, a valid Ignition configuration must be passed as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data] at creation time:
+
+TIP: You can find out the instance's assigned IP by running `aws ec2 describe-instances`
+
+You now should be able to SSH into the instance using the associated IP address.
+
+In order to launch a customized FCOS instance, a valid Ignition configuration must be passed as its https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html#instancedata-add-user-data[user data] at creation time. You can use the same command from above but add `--user-data file://path/to/config.ign` argument:
 
 .Launching and customizing a new instance
 [source, bash]
 ----
-aws ec2 run-instances <other options> --image-id <ami> --user-data file://example.ign
+NAME='instance1'
+SSHKEY='my-key'     # the name of your SSH key: `aws ec2 describe-key-pairs`
+IMAGE='ami-xxx'     # the AMI ID found on the download page
+DISK='20'           # the size of the hard disk
+REGION='us-east-1'  # the target region
+TYPE='m5.large'     # the instance type
+SUBNET='subnet-xxx' # the subnet: `aws ec2 describe-subnets`
+SECURITY_GROUPS='sg-xx' # the security group `aws ec2 describe-security-groups`
+USERDATA='/path/to/config.ign' # path to your Ignition config
+aws ec2 run-instances                     \
+    --region $REGION                      \
+    --image-id $IMAGE                     \
+    --instance-type $TYPE                 \
+    --key-name $SSHKEY                    \
+    --subnet-id $SUBNET                   \
+    --security-group-ids $SECURITY_GROUPS \
+    --user-data "file://${USERDATA}"      \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${NAME}}]" \
+    --block-device-mappings "VirtualName=/dev/xvda,DeviceName=/dev/xvda,Ebs={VolumeSize=${DISK}}"
 ----
 
 NOTE: By design, cloud-init configuration and startup scripts are not supported on FCOS. Instead, it is recommended to encode any startup logic as systemd service units in the Ignition configuration.


### PR DESCRIPTION
Adds some more options rather than leaving it so open ended.
I typically need it to be more "fill in the blank" and push the button
like our other provisioning pages are.