### PR TITLE
os-extensions: fix yaml file for dns issue

### DIFF
--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -33,6 +33,7 @@ systemd:
         # We run after `systemd-machine-id-commit.service` to ensure that
         # `ConditionFirstBoot=true` services won't rerun on the next boot.
         After=systemd-machine-id-commit.service
+        Wants=network-online.target
         After=network-online.target
         # We run before `zincati.service` to avoid conflicting rpm-ostree
         # transactions.


### PR DESCRIPTION
In some cases, the example fails because dns is not setup yet.
This change will ensure rpm-ostree can resolve the repo hostname.