### PR TITLE
provisioning/ibmcloud: a few updates

### DIFF
--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -61,10 +61,10 @@ ibmcloud cos upload --bucket=$BUCKET --key=$FILE --file=$FILE
 ----
 IMAGE=${FILE:0:-6}     # pull off .qcow2
 IMAGE=${IMAGE//[._]/-} # replace . and _ with -
-ibmcloud is image-create $IMAGE --file "cos://${REGION}/${BUCKET}/${FILE}" --os-name centos-7-amd64
+ibmcloud is image-create $IMAGE --file "cos://${REGION}/${BUCKET}/${FILE}" --os-name centos-8-amd64
 ----
 
-NOTE: Specifying `--os-name centos-7-amd64` is required for now until IBM expands the list of OS types.
+NOTE: Specifying `--os-name centos-8-amd64` is required for now until IBM expands the list of OS types.
 
 You'll have to wait for the image creation process to finish and go from `pending` to `available` before you can use the image. Monitor with the following command:
 


### PR DESCRIPTION
```
commit 7ec651796f27467c8ebce46661ec666fa6e7753f
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 20 09:43:47 2021 -0400

    provisioning/ibmcloud: update to use centos-8-amd64 profile
    
    The newer profile exists now and seems to work so we might as
    well use it.

commit c9d22fd8540f8cc6de02fdb5d306e6175eaa095c
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Wed Oct 20 09:43:20 2021 -0400

    provisioning/ibmcloud: update floating-ip-update call
    
    The command now reports:
    
    ```
    Deprecated: '--nic-id' option is deprecated, use '--nic' option instead.
    ```
```
