### PR TITLE
Add xrefs and reorder final few tutorials

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -54,8 +54,8 @@
 ** xref:tutorial-autologin.adoc[Enabling autologin and custom hostname]
 ** xref:tutorial-services.adoc[Starting a service on first boot]
 ** xref:tutorial-containers.adoc[SSH access and starting containers]
-** xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]
 ** xref:tutorial-user-systemd-unit-on-boot.adoc[Launching a user-level systemd unit on boot]
+** xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]
 * Reference pages
 ** xref:platforms.adoc[Platforms]
 ** xref:fcos-projects.adoc[Projects Using Fedora CoreOS]

--- a/modules/ROOT/pages/tutorial-conclusion.adoc
+++ b/modules/ROOT/pages/tutorial-conclusion.adoc
@@ -1,0 +1,3 @@
+= Conclusion
+
+In these tutorials we have learned a little bit about Fedora CoreOS. We have learned how it is delivered as a pre-created disk image, how it is provisioned in an automated fashion via Ignition, and also how automated updates are configured and achieved via Zincati and rpm-ostree. The next step is to try out Fedora CoreOS for your own use cases and https://github.com/coreos/fedora-coreos-tracker/blob/main/README.md#communication-channels-for-fedora-coreos[join the community]!

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -230,4 +230,4 @@ virsh destroy fcos
 virsh undefine --remove-all-storage fcos
 ----
 
-You may now proceed with the xref:tutorial-updates.adoc[next tutorial].
+You may now proceed with the xref:tutorial-user-systemd-unit-on-boot.adoc[next tutorial].

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -14,9 +14,9 @@ xref:tutorial-services.adoc[Starting a service on first boot]: In this tutorial,
 
 xref:tutorial-containers.adoc[SSH access and starting containers]: In this tutorial, you will learn how to start a container at first boot with podman.
 
-xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]: In this tutorial, you will learn how automatic updates are handled in Fedora CoreOS and how to rollback in case of failures.
-
 xref:tutorial-user-systemd-unit-on-boot.adoc[Launching a user-level systemd unit on boot]: There are times when it’s helpful to launch a user-level systemd unit without having to log in. This tutorial demonstrates creating a user-level systemd unit that launches on boot.
+
+xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]: In this tutorial, you will learn how automatic updates are handled in Fedora CoreOS and how to rollback in case of failures.
 
 == Virtualization with `libvirt`
 

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -261,6 +261,4 @@ virsh destroy fcos
 virsh undefine --remove-all-storage fcos
 ----
 
-== Conclusion
-
-In these tutorials we have learned a little bit about Fedora CoreOS. We have learned how it is delivered as a pre-created disk image, how it is provisioned in an automated fashion via Ignition, and also how automated updates are configured and achieved via Zincati and rpm-ostree. The next step is to try out Fedora CoreOS for your own use cases and https://github.com/coreos/fedora-coreos-tracker/blob/main/README.md#communication-channels-for-fedora-coreos[join the community]!
+include::tutorial-conclusion.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -189,3 +189,5 @@ You can then take down the instance. First, disconnect from the serial console b
 virsh destroy fcos
 virsh undefine --remove-all-storage fcos
 ----
+
+You may now proceed with the xref:tutorial-updates.adoc[next tutorial].


### PR DESCRIPTION
Hi, thanks for these tutorials! It's helped me a lot as I learn more about CoreOS

I noticed that `tutorial-updates.adoc` has a conclusion, which means it's probably meant to be the final tutorial, as there is no `xref` linking it to `tutorial-user-systemd-unit-on-boot.adoc`

This PR reorders the tutorials, so that _Testing Fedora CoreOS updates_ is the final one, and the one before is _Launching a user-level systemd unit on boot_. The links are also updated to reflect this.