### PR TITLE
Fix up inconsistencies in the Raspberry Pi documentation.

### DIFF
--- a/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
+++ b/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
@@ -3,9 +3,9 @@
 Fedora CoreOS produces 64-bit ARM (`aarch64`) artifacts. These images can be used as the Operating System for the Raspberry Pi 4 device. Before trying to get FCOS up and running on your Raspberry Pi 4 you'll want to xref:#_updating_eeprom_on_raspberry_pi_4[Update the EEPROM] to the latest version and choose how you want to boot the Raspberry Pi 4. There are two options:
 
 - xref:#_installing_fcos_and_booting_via_u_boot[Installing FCOS and Booting via U-Boot]
-- xref:#_installing_fcos_and_booting_via_uefi[Installing FCOS and Booting via UEFI]
+- xref:#_installing_fcos_and_booting_via_uefi[Installing FCOS and Booting via EDK2]
 
-U-Boot is the way the Raspberry Pi 4 has traditionally been booted. The https://rpi4-uefi.dev/about/[UEFI Firmware] is an effort to provide a layer that will make RPi4 ServerReady (SBBC compliant) similar to most larger 64-bit ARM servers.
+U-Boot is the way the Raspberry Pi 4 has traditionally been booted. The https://rpi4-uefi.dev/about/[EDK2 Firmware] is an effort to provide a layer that will make RPi4 SystemReady ES (SBBR compliant) similar to most larger 64-bit ARM servers.
 
 ## Updating EEPROM on Raspberry Pi 4
 
@@ -34,7 +34,7 @@ At this point you can follow https://www.raspberrypi.org/documentation/computers
 
 To run FCOS on a Raspberry Pi 4 via U-Boot the SD card or USB disk needs to be prepared on another system and then the disk moved to the RPi4. After writing FCOS to the disk a few more files will need to be copied in place on the EFI partition of the FCOS disk. Check out the https://www.raspberrypi.com/documentation/computers/configuration.html#boot-folder-contents[Raspberry Pi Documentation] to read more about what these files are for.
 
-In this case we can grab these files from the `uboot-images-armv8`, `bcm283x-firmware`, `bcm283x-overlays` RPMs from the Fedora Linux repositories. First download them and store them in a temporary directory on your system:
+In this case we can grab these files from the `uboot-images-armv8`, `bcm2711-firmware`, `bcm283x-firmware`, `bcm283x-overlays` RPMs from the Fedora Linux repositories. First download them and store them in a temporary directory on your system:
 
 [source, bash]
 ----
@@ -61,7 +61,7 @@ sudo coreos-installer install --architecture=aarch64 -i config.ign $FCOSDISK
 
 NOTE: Make sure you provide an xref:producing-ign.adoc[Ignition config] when you run `coreos-installer`.
 
-Now mount the EFI partition and copy the files over:
+Now mount the ESP partition and copy the files over:
 
 [source, bash]
 ----
@@ -77,21 +77,21 @@ Now take the USB/SD card and attach it to the RPi4 and boot.
 TIP: It can take some time to boot, especially if the disk is slow. Be patient. You may not see anything on the screen for 20-30 seconds.
 
 
-## Installing FCOS and Booting via UEFI
+## Installing FCOS and Booting via EDK2
 
-There is a UEFI firmware implementation for the RPi4 (https://github.com/pftf/RPi4/[pftf/RPi4]) that attempts to make the RPi4 ServerReady (SBBC compliant) and allows you to pretend that the RPi4 is just like any other server hardware with UEFI.
+There is a EDK2 UEFI firmware implementation for the RPi4 (https://github.com/pftf/RPi4/[pftf/RPi4]) that attempts to make the RPi4 SystemReady ES (SBBR compliant) and allows you to pretend that the RPi4 is similar to any other SystemReady server hardware.
 
 You can write the firmware to a disk (USB or SD card) and then boot/install FCOS as you would on any bare metal server. However, the firmware files need to be on an SD card or USB disk and will take up either the SD card slot or a USB slot. Depending on your needs this may be acceptable or not. Depending on the answer you have a few options:
 
-- Separate UEFI Firmware Disk (aka "separate disk mode")
-- Combined Fedora CoreOS + UEFI Firmware Disk (aka "combined disk mode")
+- Separate Firmware Disk (aka "separate disk mode")
+- Combined Fedora CoreOS + EDK2 Firmware Disk (aka "combined disk mode")
 
 These options are covered in the following sections. Regardless of which option you choose you'll want to consider if you need to either xref:#_uefi_firmware_changing_the_3g_limit[Change the 3G RAM limit] or xref:#_uefi_firmware_gpio_via_devicetree[Enable DeviceTree Boot].
 
 
-### UEFI: Separate UEFI Firmware Disk Mode
+### EDK2: Separate Firmware Disk Mode
 
-In separate disk mode the UEFI firmware will take up either the SD card slot or a USB slot on your RPi4. Once the firmware disk is attached to the system you'll be able to follow the xref:bare-metal.adoc[bare metal install documentation] and pretend like the RPi4 is any other server hardware.
+In separate disk mode the EDK2 firmware will take up either the SD card slot or a USB slot on your RPi4. Once the firmware disk is attached to the system you'll be able to follow the xref:bare-metal.adoc[bare metal install documentation] and pretend like the RPi4 is any other server hardware.
 
 To create a disk (SD or USB) with the firmware on it you can do something like:
 
@@ -112,11 +112,11 @@ sudo umount /tmp/UEFIdisk
 
 Attaching this disk to your Pi4 you can now install FCOS as you would on any bare metal server.
 
-NOTE: The separate UEFI firmware disk will need to stay attached permanently for future boots to work.
+NOTE: The separate firmware disk will need to stay attached permanently for future boots to work.
 
-### UEFI: Combined Fedora CoreOS + UEFI Firmware Disk
+### EDK2: Combined Fedora CoreOS + EDK2 Firmware Disk
 
-In combined disk mode the UEFI firmware will live inside the EFI partition of Fedora CoreOS, allowing for a single disk to be used for the UEFI firmware and FCOS.
+In combined disk mode the EDK2 firmware will live inside the EFI partition of Fedora CoreOS, allowing for a single disk to be used for the EDK2 firmware and FCOS.
 
 There are a few ways to achieve this goal:
 
@@ -124,9 +124,9 @@ There are a few ways to achieve this goal:
 - Prepare Pi4 Disk on Alternate Machine
 
 
-#### UEFI: Combined Disk Mode Direct Install
+#### EDK2: Combined Disk Mode Direct Install
 
-When performing a direct install, meaning you boot (via the UEFI firmware) into the Fedora CoreOS live environment (ISO or PXE) and run `coreos-installer`, you can mount the EFI partition (2nd partition) of the installed FCOS disk after the install is complete and copy the UEFI firmware files over:
+When performing a direct install, meaning you boot (via the EDK2 firmware) into the Fedora CoreOS live environment (ISO or PXE) and run `coreos-installer`, you can mount the EFI partition (2nd partition) of the installed FCOS disk after the install is complete and copy the EDK2 firmware files over:
 
 [source, bash]
 ----
@@ -144,9 +144,9 @@ Now you can remove the extra disk from the RPi4 and reboot the machine.
 
 TIP: It can take some time to boot, especially if the disk is slow. Be patient. You may not see anything on the screen for 20-30 seconds.
 
-#### UEFI: Combined Disk Mode Alternate Machine Disk Preparation
+#### EDK2: Combined Disk Mode Alternate Machine Disk Preparation
 
-When preparing the RPi4 disk from an alternate machine (i.e. creating the disk from your laptop) then you can mount the 2nd partition **after** running `coreos-installer` and pull down the UEFI firmware files.
+When preparing the RPi4 disk from an alternate machine (i.e. creating the disk from your laptop) then you can mount the 2nd partition **after** running `coreos-installer` and pull down the EDK2 firmware files.
 
 First, run `coreos-installer` to install to the target disk:
 
@@ -156,7 +156,7 @@ FCOSDISK=/dev/sdX
 sudo coreos-installer install --architecture=aarch64 -i config.ign $FCOSDISK
 ----
 
-Now you can mount the 2nd partition and pull down the UEFI firmware files:
+Now you can mount the 2nd partition and pull down the EDK2 firmware files:
 
 [source, bash]
 ----
@@ -176,17 +176,17 @@ Now take the USB/SD card and attach it to the RPi4 and boot.
 
 TIP: It can take some time to boot, especially if the disk is slow. Be patient. You may not see anything on the screen for 20-30 seconds.
 
-### UEFI Firmware: Changing the 3G limit
+### EDK2 Firmware: Changing the 3G limit
 
-If you have a Pi4 with more than 3G of memory you'll most likely want to disable the 3G memory limitation. In the UEFI firmware menu go to 
+If you have a Pi4 with more than 3G of memory you'll most likely want to disable the 3G memory limitation. In the EDK2 firmware menu go to 
 
 - `Device Manager` -> `Raspberry Pi Configuration` -> `Advanced Configuration` -> `Limit RAM to 3GB` -> `Disabled`
 - `F10` to save -> `Y` to confirm
 - `Esc` to top level menu and select `reset` to cycle the system.
 
-### UEFI Firmware: GPIO via DeviceTree
+### EDK2 Firmware: GPIO via DeviceTree
 
-With the UEFI Firmware in ACPI mode (the default) you won't get access to GPIO (i.e. no Pi HATs will work). To get access to GPIO pins you'll need to change the setting to DeviceTree mode in the UEFI menus.
+With the EDK2 Firmware in ACPI mode (the default) you won't get access to GPIO (i.e. no Pi HATs will work). To get access to GPIO pins you'll need to change the setting to DeviceTree mode in the EDK2 menus.
 
 - `Device Manager` -> `Raspberry Pi Configuration` -> `Advanced Configuration` -> `System Table Selection` -> `DeviceTree`
 - `F10` to save -> `Y` to confirm
@@ -201,3 +201,5 @@ After boot you should see entries under `/proc/device-tree/` and also see `/dev/
 [core@localhost ~]$ ls /dev/gpiochip* 
 /dev/gpiochip0  /dev/gpiochip1
 ----
+
+You can interface with GPIO from userspace using libgpiod and assoicated bindings or tools.


### PR DESCRIPTION
There's a number of incorrect and inconsistent pieces in the
documentation so let's fix those up to avoid confustion:
* Both EDK2 and U-Boot are UEFI firmwares, use EDK2 to avoid confusion.
* The EDK2 firmware does NOT make the RPi4 appear to be ServerReady, it
  makes it close to SystemReaady ES. These are not the same.
* s/SBBC/SBBR
* Add missing Raspberry Pi 4 firmware package.
* Add note about using GPIO from userspace.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>