### PR TITLE
Don't use '--tty-' for podman shell aliases

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -57,7 +57,7 @@ To make it simpler to type, you may also add the following alias to your shell c
 
 [source,bash]
 ----
-alias butane='podman run --rm --tty --interactive \
+alias butane='podman run --rm --interactive       \
               --security-opt label=disable        \
               --volume ${PWD}:/pwd --workdir /pwd \
               quay.io/coreos/butane:release'

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -55,18 +55,18 @@ To make it simpler to type, you may add the following aliases to your shell conf
 
 [source,bash]
 ----
-alias butane='podman run --rm --tty --interactive \
+alias butane='podman run --rm --interactive       \
               --security-opt label=disable        \
               --volume ${PWD}:/pwd --workdir /pwd \
               quay.io/coreos/butane:release'
 
 alias coreos-installer='podman run --pull=always            \
-                        --rm --tty --interactive            \
+                        --rm --interactive                  \
                         --security-opt label=disable        \
                         --volume ${PWD}:/pwd --workdir /pwd \
                         quay.io/coreos/coreos-installer:release'
 
-alias ignition-validate='podman run --rm --tty --interactive \
+alias ignition-validate='podman run --rm --interactive       \
                          --security-opt label=disable        \
                          --volume ${PWD}:/pwd --workdir /pwd \
                          quay.io/coreos/ignition-validate:release'


### PR DESCRIPTION
Using '--tty' conflicts with stdin redirection:
https://docs.podman.io/en/latest/markdown/podman-run.1.html#tty-t