### PR TITLE
provisioning/rpi4: minor updates

### DIFF
--- a/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
+++ b/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
@@ -38,7 +38,7 @@ In this case we can grab these files from the `uboot-images-armv8`, `bcm2711-fir
 
 [source, bash]
 ----
-RELEASE=34 # The target Fedora Release. Use the same one that current FCOS is based on.
+RELEASE=35 # The target Fedora Release. Use the same one that current FCOS is based on.
 mkdir -p /tmp/RPi4boot/boot/efi/
 sudo dnf install -y --downloadonly --release=$RELEASE --forcearch=aarch64 --destdir=/tmp/RPi4boot/  uboot-images-armv8 bcm283x-firmware bcm283x-overlays
 ----

--- a/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
+++ b/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
@@ -69,7 +69,7 @@ FCOSEFIPARTITION=$(lsblk $FCOSDISK -J -oLABEL,PATH  | jq -r '.blockdevices[] | s
 mkdir /tmp/FCOSEFIpart
 sudo mount $FCOSEFIPARTITION /tmp/FCOSEFIpart
 sudo rsync -avh --ignore-existing /tmp/RPi4boot/boot/efi/ /tmp/FCOSEFIpart/
-sudo umount ${FCOSDISK}2
+sudo umount $FCOSEFIPARTITION
 ----
 
 Now take the USB/SD card and attach it to the RPi4 and boot.


### PR DESCRIPTION
```
commit 5d3b1ae2e8922ef815931ac675d63d8a96925cd0
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Dec 10 15:06:48 2021 -0500

    provisioning/rpi4: update variable
    
    When we switched over to detecting/using $FCOSEFIPARTITION we should
    have updated the `umount` call to use that variable instead.

commit cd371ad3da332c4bc7f59fe1550cf0fe5a338be9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri Dec 10 15:05:51 2021 -0500

    provisioning/rpi4: update RELEASE var to 35
    
    FCOS is based on Fedora 35 now.
```
