### PR TITLE
build.sh: Explicitely use Antora 2.3.4 for now

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-image="docker.io/antora/antora"
+image="docker.io/antora/antora:2.3.4"
 cmd="--html-url-extension-style=indexify site.yml"
 
 if [ "$(uname)" == "Darwin" ]; then


### PR DESCRIPTION
Antora v3 has been released and there are unresolved incompatibilities.

See https://discussion.fedoraproject.org/t/antora-v3-release-and-impact-on-fedora-docs/35788