### PR TITLE
Update to reflect coreos-installer instructions

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -8,7 +8,8 @@ STREAM="stable"
 # as an installed binary:
 coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
 # or as a container:
-podman run --pull=always --rm -v $HOME/.local/share/libvirt/images/:/data -w /data \
+podman run --pull=always --privileged --rm \
+    -v /dev:/dev -v /run/udev:/run/udev -v $HOME/.local/share/libvirt/images/:/data -w /data \
     quay.io/coreos/coreos-installer:release download -s "${STREAM}" -p qemu -f qcow2.xz --decompress
 ----
 +


### PR DESCRIPTION
From https://coreos.github.io/coreos-installer/getting-started/#run-from-a-container, added additional switches to `podman run` command. This prevents `Error: building HTTP client` from occuring.