### PR TITLE
Rework live image docs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -57,6 +57,7 @@
 ** xref:tutorial-user-systemd-unit-on-boot.adoc[Launching a user-level systemd unit on boot]
 ** xref:tutorial-updates.adoc[Testing Fedora CoreOS updates]
 * Reference pages
+** xref:live-reference.adoc[Live ISO/PXE reference]
 ** xref:platforms.adoc[Supported Platforms]
 ** xref:fcos-projects.adoc[Projects Using Fedora CoreOS]
 ** xref:update-barrier-signing-keys.adoc[Signing keys and updates]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 * Provisioning Machines
 ** xref:stream-metadata.adoc[Stream metadata]
 ** xref:bare-metal.adoc[Installing on Bare Metal]
-** xref:live-booting-ipxe.adoc[Live-booting via PXE or iPXE]
+** xref:live-booting.adoc[Running directly from RAM]
 ** xref:provisioning-aliyun.adoc[Booting on Alibaba Cloud]
 ** xref:provisioning-aws.adoc[Booting on AWS]
 ** xref:provisioning-azure.adoc[Booting on Azure]

--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 * Provisioning Machines
 ** xref:stream-metadata.adoc[Stream metadata]
 ** xref:bare-metal.adoc[Installing on Bare Metal]
-** xref:live-booting-ipxe.adoc[Live-booting via iPXE]
+** xref:live-booting-ipxe.adoc[Live-booting via PXE or iPXE]
 ** xref:provisioning-aliyun.adoc[Booting on Alibaba Cloud]
 ** xref:provisioning-aws.adoc[Booting on AWS]
 ** xref:provisioning-azure.adoc[Booting on Azure]

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -114,7 +114,7 @@ LABEL pxeboot
 IPAPPEND 2
 ----
 
-== PXE rootfs image
+== PXE images
 
 include::pxe-artifacts.adoc[]
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -19,7 +19,7 @@ To install FCOS onto bare metal using the live ISO interactively, follow these s
 - Download the latest ISO image from the https://getfedora.org/coreos/download?tab=metal_virtualized&stream=stable[download page] or with podman (see https://coreos.github.io/coreos-installer/cmd/download/[documentation] for options):
 [source, bash]
 ----
-podman run --privileged --pull=always --rm -v .:/data -w /data \
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -s stable -p metal -f iso
 ----
 
@@ -49,7 +49,7 @@ To install from PXE, follow these steps:
 - Download an FCOS PXE kernel, initramfs, and rootfs image:
 [source, bash]
 ----
-podman run --privileged --pull=always --rm -v .:/data -w /data \
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -f pxe
 ----
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -53,7 +53,7 @@ podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -f pxe
 ----
 
-NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 3 GiB otherwise. You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
+NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise. You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
 
 - Follow this example `pxelinux.cfg` for booting the installer images with PXELINUX:
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -70,7 +70,7 @@ LABEL pxeboot
 IPAPPEND 2
 ----
 
-For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
+For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`. For other supported kernel command-line options, see the https://coreos.github.io/coreos-installer/getting-started/#kernel-command-line-options-for-coreos-installer-running-as-a-service[coreos-installer docs], but note that `coreos-installer pxe customize` (see below) is more flexible. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
 
 === Installing from iPXE
 
@@ -95,7 +95,7 @@ initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.i
 boot
 ----
 
-For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
+For other supported kernel command-line options, see the https://coreos.github.io/coreos-installer/getting-started/#kernel-command-line-options-for-coreos-installer-running-as-a-service[coreos-installer docs], but note that `coreos-installer pxe customize` (see below) is more flexible. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
 
 == Installing from the container
 
@@ -125,69 +125,43 @@ NOTE: The metal image uses a hybrid partition layout which supports both BIOS an
 
 When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-install --image-file <PATH>`.
 
-== Automated ISO/PXE installs with Ignition embedding
+== Customizing installation
 
-Many system administrators will want to perform fully unattended persistent installations with the live ISO. Some documentation on this is on the upstream installer site: https://coreos.github.io/coreos-installer/customizing-install/[customizing install].
+The `coreos-installer iso customize` and `coreos-installer pxe customize` commands can be used to create customized ISO and PXE images with site-specific configuration, including the ability to perform unattended installations of Fedora CoreOS.
 
-To emphasize, there are *two* Ignition configurations here; the first config ("ISO Ignition") will commonly embed a second rendered configuration that runs on the "target" installation.
+For example:
 
-First, generate `target.ign` (the file can be named anything) - the configuration that will be passed to `coreos-installer`.  Then, using e.g. `butane`, embed it as a file in your ISO ignition, and use a custom systemd unit to pass it to `coreos-installer`:
-
-[source,yaml]
+[source,bash,subs="attributes"]
 ----
-variant: fcos
-version: 1.1.0
-storage:
-  files:
-    - path: /etc/target.ign
-      contents:
-        inline: |
-          Replace this bit with a real butane directive that
-          fetches the target Ignition however you like e.g.:
-          local: target.ign
-      mode: 0644
-systemd:
-  units:
-    - name: my-coreos-installer.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Run CoreOS Installer
-        Requires=coreos-installer-pre.target
-        After=coreos-installer-pre.target
-        OnFailure=emergency.target
-        OnFailureJobMode=replace-irreversibly
-
-        # Can be removed if install doesn't reference remote resources with
-        # --stream, --image-url, or --ignition-url
-        After=network-online.target
-        Wants=network-online.target
-
-        [Service]
-        Type=oneshot
-        ExecStart=/usr/bin/coreos-installer install -i /etc/target.ign /dev/sda
-        ExecStart=/usr/bin/systemctl --no-block reboot
-        StandardOutput=kmsg+console
-        StandardError=kmsg+console
-
-        [Install]
-        RequiredBy=default.target
-
+# Create customized.iso which:
+# - Automatically installs to /dev/sda
+# - Provisions the installed system with config.ign
+# - Uses network configuration from static-ip.nmconnection
+# - Trusts HTTPS certificates signed by ca.pem
+# - Runs post.sh after installing
+coreos-installer iso customize \
+    --dest-device /dev/sda \
+    --dest-ignition config.ign \
+    --network-keyfile static-ip.nmconnection \
+    --ignition-ca ca.pem \
+    --post-install post.sh \
+    -o custom.iso fedora-coreos-{stable-version}-live.x86_64.iso
+# Same, but create a customized PXE initramfs image
+coreos-installer pxe customize \
+    --dest-device /dev/sda \
+    --dest-ignition config.ign \
+    --network-keyfile static-ip.nmconnection \
+    --ignition-ca ca.pem \
+    --post-install post.sh \
+    -o custom-initramfs.img fedora-coreos-{stable-version}-live-initramfs.x86_64.img
 ----
 
-Note that this configuration is completely independent of the config passed for the ISO/PXE boot, in the sense that e.g. no systemd units and files written from the live Ignition will be preserved when booted into the final installed system, unless you take explicit action to preserve it.
-
-There is however explicit support for https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/#_via_coreos_installer_copy_network[copying network configuration] with `coreos-installer`.
-
-A generally useful technique is to add more systemd units that run before or after the systemd unit that invokes `coreos-installer`.  For example, you can run a systemd unit which pulls a container and does hardware validation.
-
-An example post-install action: Some provisioning systems may require a callback to the PXE server to be switched to "boot from local disk" via a HTTP request; this can similarly be done via a systemd unit that is scheduled `After=my-coreos-installer.service` that uses
-`ExecStart=/usr/bin/curl` or pulling a container which makes the HTTP request.
+For details on available customizations, see the https://coreos.github.io/coreos-installer/customizing-install/#customize-options[coreos-installer documentation].
 
 === ISO installation on diverse hardware
 
 Commonly bare metal systems will have a diversity of hardware - some systems may have NVMe drives `/dev/nvme*`, whereas others have `/dev/sd*` for example.  You will almost certainly have to template the value of `/dev/sda` above.
 
-A useful approach is to script generating a per-machine `.iso`.  If you have a hardware database (whether a text file in git or relational database) then it will work to generate a per-machine `target-dell.ign` and `target-hp.ign` for example, embed that with the generic `iso.ign` to generate `fedora-coreos-install-dell.iso` and `fedora-coreos-install-hp.iso`.
+A useful approach is to script generating a per-machine `.iso`.  If you have a hardware database (whether a text file in git or relational database) then it will work to generate a per-machine `target-dell.ign` and `target-hp.ign` for example, and specify that to `--dest-ignition` alongside the appropriate `--dest-device` to generate `fedora-coreos-install-dell.iso` and `fedora-coreos-install-hp.iso`.
 
-Alternatively, instead of generating per-machine ISOs, you can have the ISO Ignition pull a privileged container which inspects the target system, and dynamically invokes `coreos-installer`.
+Alternatively, instead of generating per-machine ISOs, you can have a `--pre-install` script run a privileged container which inspects the target system and writes an appropriate https://coreos.github.io/coreos-installer/customizing-install/#config-file-format[installer config] to `/etc/coreos/installer.d`.

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -38,7 +38,7 @@ sudo coreos-installer install /dev/sda \
 
 Once the installation is complete, you can simply `sudo reboot`. After rebooting, the first boot process begins. It is at this time that Ignition ingests the configuration file and provisions the system as specified.
 
-For more advanced ISO installs, including automation, see below.
+For more advanced ISO installs, including automation, see below. For more about the live ISO image, see the xref:live-reference.adoc[live image reference].
 
 TIP: Check out `coreos-installer install --help` for more options on how to install Fedora CoreOS.
 
@@ -70,7 +70,7 @@ LABEL pxeboot
 IPAPPEND 2
 ----
 
-For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`.
+For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
 
 === Installing from iPXE
 
@@ -94,6 +94,8 @@ initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.i
 
 boot
 ----
+
+For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
 
 == Installing from the container
 
@@ -122,10 +124,6 @@ To download the 4kn native metal image with `coreos-installer download`, use the
 NOTE: The metal image uses a hybrid partition layout which supports both BIOS and UEFI booting.
 
 When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-install --image-file <PATH>`.
-
-== PXE images
-
-include::pxe-artifacts.adoc[]
 
 == Automated ISO/PXE installs with Ignition embedding
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -127,15 +127,7 @@ When you're finally ready to install FCOS, you can point it at your downloaded i
 
 == Automated ISO/PXE installs with Ignition embedding
 
-The Fedora CoreOS live environment is also CoreOS in the sense that it can boot via Ignition, execute containers, etc.  It includes all of the same content.
-
-As noted above for live PXE, the ISO live environment does not have to actually perform a persistent installation.  You can boot it from a read-only medium such as a physical CD-ROM/DVD, and do everything you do on any other Fedora CoreOS environment.  It also works to boot from a USB stick.  Each boot will re-run the Ignition config, and changes will not persist by default.
-
-For the ISO, the mechanism to do this is `coreos-installer ignition iso embed`, which will create a new `.iso` file that combines your configuration with the ISO.  Similarly, there is `coreos-installer pxe ignition wrap` for the PXE case.
-
-However, many system administrators will want to perform fully unattended persistent installations instead of running stateless.
-
-Some documentation on this is on the upstream installer site: https://coreos.github.io/coreos-installer/customizing-install/[customizing install].
+Many system administrators will want to perform fully unattended persistent installations with the live ISO. Some documentation on this is on the upstream installer site: https://coreos.github.io/coreos-installer/customizing-install/[customizing install].
 
 To emphasize, there are *two* Ignition configurations here; the first config ("ISO Ignition") will commonly embed a second rendered configuration that runs on the "target" installation.
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -98,22 +98,6 @@ NOTE: The metal image uses a hybrid partition layout which supports both BIOS an
 
 When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-install --image-file <PATH>`.
 
-== Live PXE
-
-In this model, rather than performing a "persistent" installation to disk, you can run directly from RAM. This is useful in e.g. "diskless" scenarios.
-The steps are similar to the above, just omit the `coreos.inst` arguments, and instead have the system itself run Ignition:
-
-[source,subs="attributes"]
-----
-DEFAULT pxeboot
-TIMEOUT 20
-PROMPT 0
-LABEL pxeboot
-    KERNEL fedora-coreos-{stable-version}-live-kernel-x86_64
-    APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
-IPAPPEND 2
-----
-
 == PXE images
 
 include::pxe-artifacts.adoc[]

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -110,7 +110,7 @@ TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
     KERNEL fedora-coreos-{stable-version}-live-kernel-x86_64
-    APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign systemd.unified_cgroup_hierarchy=0
+    APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -42,7 +42,11 @@ For more advanced ISO installs, including automation, see below.
 
 TIP: Check out `coreos-installer install --help` for more options on how to install Fedora CoreOS.
 
-== Installing from PXE
+== Installing from the network
+
+NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise. You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
+
+=== Installing from PXE
 
 To install from PXE, follow these steps:
 
@@ -52,8 +56,6 @@ To install from PXE, follow these steps:
 podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release download -f pxe
 ----
-
-NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise. You can install in either legacy boot (BIOS) mode or in UEFI mode, regardless of what mode the OS will use once installed.
 
 - Follow this example `pxelinux.cfg` for booting the installer images with PXELINUX:
 
@@ -69,6 +71,29 @@ IPAPPEND 2
 ----
 
 For more details on how to use this information, see this https://dustymabe.com/2019/01/04/easy-pxe-boot-testing-with-only-http-using-ipxe-and-libvirt/[blog post] for testing a PXE installation via a local VM and `libvirt`.
+
+=== Installing from iPXE
+
+An iPXE-capable machine needs to be provided with a relevant Boot Script to fetch and load FCOS artifacts.
+
+The example below shows how to load those directly from Fedora infrastructure. For performance and reliability reasons it is recommended to mirror them on the local infrastructure, and then tweak the `BASEURL` as needed.
+
+[source,subs="attributes"]
+----
+#!ipxe
+
+set STREAM stable
+set VERSION {stable-version}
+set INSTALLDEV /dev/sda
+set CONFIGURL https://example.com/config.ign
+
+set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/$\{STREAM}/builds/$\{VERSION}/x86_64
+
+kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img coreos.inst.install_dev=$\{INSTALLDEV} coreos.inst.ignition_url=$\{CONFIGURL}
+initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.img
+
+boot
+----
 
 == Installing from the container
 

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -1,16 +1,12 @@
 = Booting live Fedora CoreOS via PXE or iPXE
 
-This guide shows how to boot a transient Fedora CoreOS (FCOS) system via PXE or iPXE. By default this will run FCOS in a stateless way, directly from RAM. Separately, FCOS can also be xref:bare-metal.adoc[installed to disk].
+This guide shows how to boot a transient Fedora CoreOS (FCOS) system via PXE or iPXE. By default this will run FCOS in a stateless way, directly from RAM. Separately, FCOS can also be xref:bare-metal.adoc[installed to disk]. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
 
 == Prerequisite
 
 Before booting FCOS, you must have an Ignition configuration file and host it somewhere (e.g. on a reachable web server). If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
 NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise.
-
-== PXE images
-
-include::pxe-artifacts.adoc[]
 
 == Booting via PXE
 

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -34,6 +34,38 @@ initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.i
 boot
 ----
 
+== Using persistent state
+
+By default, the Fedora CoreOS live environment does not store any state on disk, and is reprovisioned from scratch on every boot. However, you may choose to store some persistent state (such as container images) in a filesystem that persists across reboots. For example, here's a Butane config that configures a persistent `/var`:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.1.0
+storage:
+  disks:
+    - device: /dev/sda
+      wipe_table: true
+      partitions:
+        - label: var
+  filesystems:
+    - device: /dev/disk/by-partlabel/var
+      label: var
+      format: xfs
+      wipe_filesystem: false
+      path: /var
+      with_mount_unit: true
+----
+
+When booting a live environment, the Ignition config runs on every boot, so it should avoid wiping LUKS volumes and filesystems that you want to reuse. Instead, configure such structures so that they're created on the first boot and preserved on subsequent boots.
+
+In particular, note the following guidelines:
+
+- Avoid setting `wipe_filesystem` or `wipe_volume` for https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics[filesystems] or LUKS volumes that you intend to reuse. (You can safely set `wipe_table` or `wipe_partition_entry` when reusing a disk, since those don't modify the contents of a https://coreos.github.io/ignition/operator-notes/#partition-reuse-semantics[partition].)
+- When reusing LUKS volumes, you must configure a `key_file`. Ignition cannot reuse Clevis-backed LUKS volumes.
+- Avoid writing persistent data to RAID volumes, since Ignition cannot reuse those.
+- When writing files in persistent storage, set `overwrite` to `true` to avoid Ignition failures when reusing a filesystem that already has the file. Avoid using the `append` directive for persistent files, since the append will occur on every boot.
+
 == Update process
 
 Since the traditional FCOS upgrade process requires a disk, live-PXE systems are not able to auto-update in place. For this reason, Zincati is not running there.

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -1,6 +1,6 @@
-= Booting live Fedora CoreOS via iPXE
+= Booting live Fedora CoreOS via PXE or iPXE
 
-This guide shows how to boot a transient Fedora CoreOS (FCOS) system via iPXE. By default this will run FCOS in a stateless way, completely out of RAM. Separately, FCOS can also be installed to disk.
+This guide shows how to boot a transient Fedora CoreOS (FCOS) system via PXE or iPXE. By default this will run FCOS in a stateless way, directly from RAM. Separately, FCOS can also be xref:bare-metal.adoc[installed to disk].
 
 == Prerequisite
 
@@ -12,7 +12,31 @@ NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos
 
 include::pxe-artifacts.adoc[]
 
-== Setting up the Boot Script
+== Booting via PXE
+
+To boot from PXE, follow these steps:
+
+- Download an FCOS PXE kernel, initramfs, and rootfs image:
+[source, bash]
+----
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
+    quay.io/coreos/coreos-installer:release download -f pxe
+----
+
+- Follow this example `pxelinux.cfg` for booting the installer images with PXELINUX and running Ignition:
+
+[source,subs="attributes"]
+----
+DEFAULT pxeboot
+TIMEOUT 20
+PROMPT 0
+LABEL pxeboot
+    KERNEL fedora-coreos-{stable-version}-live-kernel-x86_64
+    APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
+IPAPPEND 2
+----
+
+== Booting via iPXE
 
 An iPXE-capable machine needs to be provided with a relevant Boot Script to fetch and load FCOS artifacts.
 

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -6,7 +6,7 @@ This guide shows how to boot a transient Fedora CoreOS (FCOS) system via iPXE. B
 
 Before booting FCOS, you must have an Ignition configuration file and host it somewhere (e.g. on a reachable web server). If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
-NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 3 GiB otherwise.
+NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise.
 
 == PXE images
 

--- a/modules/ROOT/pages/live-booting-ipxe.adoc
+++ b/modules/ROOT/pages/live-booting-ipxe.adoc
@@ -28,7 +28,7 @@ set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/$\{STREAM}/builds/$\{VERSION}/x86_64
 
-kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=$\{CONFIGURL} systemd.unified_cgroup_hierarchy=0
+kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=$\{CONFIGURL}
 initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.img
 
 boot

--- a/modules/ROOT/pages/live-booting.adoc
+++ b/modules/ROOT/pages/live-booting.adoc
@@ -1,12 +1,41 @@
-= Booting live Fedora CoreOS via PXE or iPXE
+= Running Fedora CoreOS directly from RAM
+:page-aliases: live-booting-ipxe.adoc
 
-This guide shows how to boot a transient Fedora CoreOS (FCOS) system via PXE or iPXE. By default this will run FCOS in a stateless way, directly from RAM. Separately, FCOS can also be xref:bare-metal.adoc[installed to disk]. For more about the live PXE image, see the xref:live-reference.adoc[live image reference].
+The Fedora CoreOS live environment is a fully functional copy of Fedora CoreOS. It can provision itself via Ignition, execute containers, and so on. The live environment can be used to xref:bare-metal.adoc[install Fedora CoreOS to disk], and can also be used to run Fedora CoreOS directly from RAM.
 
-== Prerequisite
+This guide shows how to boot a transient Fedora CoreOS (FCOS) system via ISO, PXE, or iPXE. For more about the live ISO and PXE images, see the xref:live-reference.adoc[live image reference].
 
-Before booting FCOS, you must have an Ignition configuration file and host it somewhere (e.g. on a reachable web server). If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+== Prerequisites
 
-NOTE: Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise.
+Before booting FCOS, you must have an Ignition configuration file. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+If you're booting from PXE or iPXE, you must host the Ignition config on a reachable HTTP(S) or TFTP server. Booting the live PXE image requires at least 2 GiB of RAM with the `coreos.live.rootfs_url` kernel argument, and 4 GiB otherwise.
+
+== Booting via ISO
+
+The live ISO image can be booted from a physical DVD disc, from a USB stick, or from a virtual CD drive via lights-out management (LOM) firmware.
+
+To boot from the ISO image, follow these steps:
+
+- Download the ISO image:
++
+[source,bash]
+----
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
+    quay.io/coreos/coreos-installer:release download -f iso
+----
+
+- Use `coreos-installer iso customize` to embed your Ignition config into the ISO image. For example, for an Ignition config called `config.ign`:
++
+[source,bash,subs="attributes"]
+----
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
+    quay.io/coreos/coreos-installer:release iso customize --live-ignition config.ign \
+    -o customized.iso fedora-coreos-{stable-version}-live.x86_64.iso
+----
+
+- Burn the ISO to disk. On Linux and macOS, you can use `dd`. On Windows, you can use https://rufus.ie/[Rufus] in "DD Image" mode.
+- Boot it on the target system.
 
 == Booting via PXE
 
@@ -88,6 +117,8 @@ In particular, note the following guidelines:
 
 == Update process
 
-Since the traditional FCOS upgrade process requires a disk, live-PXE systems are not able to auto-update in place. For this reason, Zincati is not running there.
+Since the traditional FCOS upgrade process requires a disk, the live environment is not able to auto-update in place. For this reason, Zincati is not running there.
 
-Instead, it is recommended that images references in the PXE configuration are regularly refreshed. Once infrastructure and configurations are updated, the live-PXE instance simply needs to be rebooted in order to start running the new FCOS version.
+For PXE-booted systems, it is recommended that images referenced in the PXE configuration are regularly refreshed. Once infrastructure and configurations are updated, the live PXE instance simply needs to be rebooted in order to start running the new FCOS version.
+
+For ISO-booted systems, the ISO image used to boot the live environment should be periodically refreshed, and the instance rebooted to update the running OS.

--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -10,6 +10,38 @@ There are multiple ways to pass the `rootfs` to a machine:
 - Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method does not require an HTTP(S) server, since the `rootfs` can be served via TFTP, but is slower and requires 4 GiB of RAM.
 - Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd. This method is slower and requires 4 GiB of RAM.
 
+== Passing an Ignition config to a live PXE system
+
+When booting Fedora CoreOS via live PXE, the kernel command line must include the arguments `ignition.firstboot ignition.platform.id=metal` to run Ignition. If running in a virtual machine, replace `metal` with the https://coreos.github.io/ignition/supported-platforms/[platform ID] for your platform, such as `qemu` or `vmware`.
+
+There are several ways to pass an Ignition config when booting Fedora CoreOS via PXE:
+
+- Add `ignition.config.url=<config-url>` to the kernel command line. Supported URL schemes include `http`, `https`, `tftp`, `s3`, and `gs`.
+
+- If running virtualized, pass the Ignition config via the hypervisor, exactly as you would when booting from a disk image. Ensure the `ignition.platform.id` kernel argument is set to the https://coreos.github.io/ignition/supported-platforms/[platform ID] for your platform.
+
+- Generate a customized version of the `initramfs` containing your Ignition config using `coreos-installer pxe customize`. For example, run:
++
+[source,bash,subs="attributes"]
+----
+coreos-installer pxe customize --live-ignition config.ign -o custom-initramfs.img \
+    fedora-coreos-{stable-version}-live-initramfs.x86_64.img
+----
+
+- If you prefer to keep the Ignition config separate from the Fedora CoreOS `initramfs` image, generate a separate initrd with the low-level `coreos-installer pxe ignition wrap` command and pass it as an additional initrd. For example, run:
++
+[source,bash]
+----
+coreos-installer pxe ignition wrap -i config.ign -o ignition.img
+----
++
+and then use a PXELINUX `APPEND` line similar to:
++
+[source,subs="attributes"]
+----
+APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img,ignition.img ignition.firstboot ignition.platform.id=metal
+----
+
 == Passing network configuration to a live ISO or PXE system
 
 On Fedora CoreOS, networking is typically configured via https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager keyfiles]. If your network requires special configuration such as static IP addresses, and your Ignition config fetches resources from the network, you cannot simply include those keyfiles in your Ignition config, since that would create a circular dependency.

--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -1,4 +1,6 @@
-:page-partial:
+= Live ISO and PXE image reference
+
+== Passing the PXE rootfs to a machine
 
 The Fedora CoreOS PXE image includes three components: a `kernel`, an `initramfs`, and a `rootfs`. All three are mandatory and the live PXE environment will not boot without them.
 

--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -9,3 +9,34 @@ There are multiple ways to pass the `rootfs` to a machine:
 - Specify only the `initramfs` file as the initrd in your PXE configuration, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument. This method requires 2 GiB of RAM and an HTTP(S) server. This is the recommended option unless you have special requirements.
 - Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method does not require an HTTP(S) server, since the `rootfs` can be served via TFTP, but is slower and requires 4 GiB of RAM.
 - Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd. This method is slower and requires 4 GiB of RAM.
+
+== Extracting PXE artifacts from a live ISO image
+
+If you want the Fedora CoreOS PXE artifacts and already have an ISO image, you can extract the PXE artifacts from it:
+
+[source,bash,subs="attributes"]
+----
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
+    quay.io/coreos/coreos-installer:release iso extract pxe \
+    fedora-coreos-{stable-version}-live.x86_64.iso
+----
+
+The command will print the paths to the artifacts it extracted.
+
+== Using the minimal ISO image
+
+In some cases, you may want to boot the Fedora CoreOS ISO image on a machine equipped with Lights-Out Management (LOM) hardware. You can upload the ISO to the LOM controller as a virtual CD image, but the ISO may be larger than the LOM controller supports.
+
+To avoid this problem, you can convert the ISO image to a smaller _minimal ISO image_ without the `rootfs`. Similar to the PXE image, the minimal ISO must fetch the `rootfs` from the network during boot.
+
+Suppose you plan to host the `rootfs` image at `https://example.com/fedora-coreos-{stable-version}-live-rootfs.x86_64.img`. This command will extract a minimal ISO image and a `rootfs` from an ISO image, embedding a `coreos.live.rootfs_url` kernel argument with the correct URL:
+
+[source,bash,subs="attributes"]
+----
+podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
+    quay.io/coreos/coreos-installer:release iso extract minimal-iso \
+    --output-rootfs fedora-coreos-{stable-version}-live-rootfs.x86_64.img \
+    --rootfs-url https://example.com/fedora-coreos-{stable-version}-live-rootfs.x86_64.img \
+    fedora-coreos-{stable-version}-live.x86_64.iso \
+    fedora-coreos-{stable-version}-live-minimal.x86_64.iso
+----

--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -1,5 +1,7 @@
 = Live ISO and PXE image reference
 
+For an introduction to running Fedora CoreOS directly from RAM, see the xref:live-booting.adoc[provisioning guide].
+
 == Passing the PXE rootfs to a machine
 
 The Fedora CoreOS PXE image includes three components: a `kernel`, an `initramfs`, and a `rootfs`. All three are mandatory and the live PXE environment will not boot without them.

--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -10,6 +10,42 @@ There are multiple ways to pass the `rootfs` to a machine:
 - Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method does not require an HTTP(S) server, since the `rootfs` can be served via TFTP, but is slower and requires 4 GiB of RAM.
 - Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd. This method is slower and requires 4 GiB of RAM.
 
+== Passing network configuration to a live ISO or PXE system
+
+On Fedora CoreOS, networking is typically configured via https://developer.gnome.org/NetworkManager/stable/nm-settings-keyfile.html[NetworkManager keyfiles]. If your network requires special configuration such as static IP addresses, and your Ignition config fetches resources from the network, you cannot simply include those keyfiles in your Ignition config, since that would create a circular dependency.
+
+Instead, you can use `coreos-installer iso customize` or `coreos-installer pxe customize` with the `--network-keyfile` option to create a customized ISO image or PXE `initramfs` image which applies your network settings before running Ignition. For example:
+
+[source,bash,subs="attributes"]
+----
+coreos-installer iso customize --network-keyfile custom.nmconnection -o custom.iso \
+    fedora-coreos-{stable-version}-live.x86_64.iso
+----
+
+If you're PXE booting and want to keep your network settings separate from the Fedora CoreOS `initramfs` image, you can also use the lower-level `coreos-installer pxe network wrap` command to create a separate initrd image, and pass that as an additional initrd. For example, run:
+
+[source,bash]
+----
+coreos-installer pxe network wrap -k custom.nmconnection -o network.img
+----
+
+and then use a PXELINUX `APPEND` line similar to:
+
+[source,subs="attributes"]
+----
+APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img,network.img ignition.firstboot ignition.platform.id=metal
+----
+
+== Passing kernel arguments to a live ISO system
+
+If you want to modify the default kernel arguments of a live ISO system, you can use the `--live-karg-{append,replace,delete}` options to `coreos-installer iso customize`. For example, if you want to enable simultaneous multithreading (SMT) even on CPUs where that is insecure, you can run:
+
+[source,bash,subs="attributes"]
+----
+coreos-installer iso customize --live-karg-delete mitigations=auto,nosmt -o custom.iso \
+    fedora-coreos-{stable-version}-live.x86_64.iso
+----
+
 == Extracting PXE artifacts from a live ISO image
 
 If you want the Fedora CoreOS PXE artifacts and already have an ISO image, you can extract the PXE artifacts from it:

--- a/modules/ROOT/pages/pxe-artifacts.adoc
+++ b/modules/ROOT/pages/pxe-artifacts.adoc
@@ -1,11 +1,9 @@
 :page-partial:
 
-NOTE: Before August 2020, the Fedora CoreOS PXE image included two components: a `kernel` image and an `initramfs` image. Beginning in August, a third `rootfs` image was added. As of October 6, the `rootfs` image is mandatory and the live PXE system will not boot without it.
+The Fedora CoreOS PXE image includes three components: a `kernel`, an `initramfs`, and a `rootfs`. All three are mandatory and the live PXE environment will not boot without them.
 
-To boot with the `rootfs` artifact, make one of the following changes to your PXE config:
+There are multiple ways to pass the `rootfs` to a machine:
 
-- Specify only the `initramfs` file as the initrd, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument.
-- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments.
-- Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd.
-
-For more information on this change, see the https://github.com/coreos/fedora-coreos-tracker/issues/390[tracker issue].
+- Specify only the `initramfs` file as the initrd in your PXE configuration, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument. This method requires 2 GiB of RAM and an HTTP(S) server. This is the recommended option unless you have special requirements.
+- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method does not require an HTTP(S) server, since the `rootfs` can be served via TFTP, but is slower and requires 4 GiB of RAM.
+- Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd. This method is slower and requires 4 GiB of RAM.

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -16,8 +16,8 @@ Whether or not a machine needs networking in the initramfs can dictate how a use
 
 * via kernel arguments
 ** these get processed by dracut modules in the initramfs on first boot
-* via `coreos-installer --copy-network`
-** by propagating the ISO/PXE install environment networking configuration
+* via `coreos-installer install --copy-network`
+** by propagating the install environment networking configuration
 * via Afterburn
 ** by applying network configuration injected by various platforms
 * via Ignition
@@ -61,14 +61,14 @@ echo "ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver
 ----
 
 
-==== via `coreos-installer --copy-network`
+==== via `coreos-installer install --copy-network`
 
 For manual bare metal install workflows it may not be preferable to use dracut kernel arguments for configuring network:
 
 - the syntax is not very user friendly
 - manipulating kernel arguments by grabbing the GRUB prompt can be challenging
 
-The `--copy-network` option to the `coreos-installer` will copy the files from `/etc/NetworkManager/system-connections/` directory into the installed system. For an interactive install this allows the user to populate networking configuration in a variety of ways before doing the install:
+The `--copy-network` option to `coreos-installer install` will copy the files from `/etc/NetworkManager/system-connections/` directory into the installed system. For an interactive install this allows the user to populate networking configuration in a variety of ways before doing the install:
 
 - using the `nmcli` command
 - using the `nmtui` TUI interface

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -16,6 +16,8 @@ Whether or not a machine needs networking in the initramfs can dictate how a use
 
 * via kernel arguments
 ** these get processed by dracut modules in the initramfs on first boot
+* via live image customization
+** by embedding network configuration in the live ISO or PXE image
 * via `coreos-installer install --copy-network`
 ** by propagating the install environment networking configuration
 * via Afterburn
@@ -59,6 +61,13 @@ interface='ens2'
 nameserver='8.8.8.8'
 echo "ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver}"
 ----
+
+
+==== via live image customization
+
+coreos-installer allows you to embed NetworkManager keyfiles directly in a live ISO or PXE image by using the `--network-keyfile` option to `coreos-installer iso customize` or `coreos-installer pxe customize`. The configuration is applied in the initramfs before Ignition runs. If you also use the `--installer-config` option or any of the `--dest-*` options to configure automatic installation, or the `--copy-network` option when installing manually, the network configuration will be forwarded to the installed system.
+
+For more details on embedding network configuration in a live image, see the xref:live-reference.adoc#_passing_network_configuration_to_a_live_iso_or_pxe_system[live ISO/PXE image reference].
 
 
 ==== via `coreos-installer install --copy-network`


### PR DESCRIPTION
Separate out bare-metal installation, live image quickstart instructions, and live image reference material into their own pages.  Document live image customization and various other details.  Do some cleanup.

Requires https://github.com/coreos/coreos-installer/pull/776.