### PR TITLE
workflows/update-versions: create PR instead

### DIFF
--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -16,15 +16,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Update versions
+        run: ci/update-versions.py
+      - name: Create commit
         run: |
           git config user.name 'CoreOS Bot'
           git config user.email coreosbot@fedoraproject.org
-          ci/update-versions.py
-      - name: Commit and push
-        run: |
           if ! git diff --quiet --exit-code; then
               git commit -am "site: update software versions ✨" \
                   -m "Triggered by update-versions GitHub Action."
-              # this bypasses CI due to GitHub recursion prevention
-              git push
           fi
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v3.8.2
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          branch: update-versions
+          push-to-fork: coreosbot-releng/fedora-coreos-docs
+          title: "site: update software versions ✨"
+          body: "Created by update-versions [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/update-versions.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/main/.github/workflows/update-versions.yml))."
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"


### PR DESCRIPTION
We can't push directly to main because of branch protection, and we can't bypass branch protection without allowing anyone with push access to the repo to do the same (by modifying a workflow).  Just create a PR instead.

Fixes #356.