### PR TITLE
Move migration help pages to the bottom

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -46,9 +46,6 @@
 ** xref:emergency-shell.adoc[Emergency Console Access]
 ** xref:debugging-with-toolbox.adoc[Debugging with Toolbx]
 ** xref:debugging-kernel-crashes.adoc[Debugging Kernel Crashes]
-* Migration notes
-** xref:migrate-ah.adoc[Migrating from Atomic Host]
-** xref:migrate-cl.adoc[Migrating from Container Linux]
 * Tutorials
 ** xref:tutorial-setup.adoc[Prerequisites for the tutorials]
 ** xref:tutorial-autologin.adoc[Enabling autologin and custom hostname]
@@ -69,4 +66,7 @@
 ** https://coreos.github.io/rpm-ostree/[rpm-ostree]
 ** https://coreos.github.io/zincati/[Zincati]
 ** https://ostreedev.github.io/ostree/[ostree]
+* Migration notes
+** xref:migrate-ah.adoc[Migrating from Atomic Host]
+** xref:migrate-cl.adoc[Migrating from Container Linux]
 * xref:faq.adoc[FAQ]


### PR DESCRIPTION
Those should be less used now thus move them at the bottom.