### PR TITLE
live-reference: support TFTP in `coreos.live.rootfs_url`

### DIFF
--- a/modules/ROOT/pages/live-reference.adoc
+++ b/modules/ROOT/pages/live-reference.adoc
@@ -8,8 +8,8 @@ The Fedora CoreOS PXE image includes three components: a `kernel`, an `initramfs
 
 There are multiple ways to pass the `rootfs` to a machine:
 
-- Specify only the `initramfs` file as the initrd in your PXE configuration, and pass an HTTP(S) URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument. This method requires 2 GiB of RAM and an HTTP(S) server. This is the recommended option unless you have special requirements.
-- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method does not require an HTTP(S) server, since the `rootfs` can be served via TFTP, but is slower and requires 4 GiB of RAM.
+- Specify only the `initramfs` file as the initrd in your PXE configuration, and pass an HTTP(S) or TFTP URL for the `rootfs` using the `coreos.live.rootfs_url=` kernel argument. This method requires 2 GiB of RAM, and is the recommended option unless you have special requirements.
+- Specify both `initramfs` and `rootfs` files as initrds in your PXE configuration. This can be done via multiple `initrd` directives, or using additional `initrd=` parameters as kernel arguments. This method is slower than the first method and requires 4 GiB of RAM.
 - Concatenate the `initramfs` and `rootfs` files together, and specify the combined file as the initrd. This method is slower and requires 4 GiB of RAM.
 
 == Passing an Ignition config to a live PXE system


### PR DESCRIPTION
This is supported as of https://github.com/coreos/fedora-coreos-config/pull/1526 and allows us to recommend `rootfs_url` even without an HTTP(S) server.