### PR TITLE
storage: add `with_mount_unit` to "Defining a filesystem" section

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -241,6 +241,7 @@ storage:
       device: /dev/md/publicdata
       format: ext4
       label: PUB
+      with_mount_unit: true
 ----
 
 == Encrypted storage (LUKS)


### PR DESCRIPTION
This one example doesn't set `with_mount_unit`, so the resulting filesystem won't be mounted by default.  Fix this.