### PR TITLE
authentication: use `mkpasswd` container

### DIFF
--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -76,11 +76,11 @@ passwd:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTey7R...
 ----
 
-To generate a secure password hash, use the `mkpasswd` command:
+To generate a secure password hash, use `mkpasswd`:
 
 [source]
 ----
-$ mkpasswd --method=yescrypt
+$ podman run -ti --rm quay.io/coreos/mkpasswd --method=yescrypt
 Password:
 $y$j9T$A0Y3wwVOKP69S.1K/zYGN.$S596l11UGH3XjN...
 ----


### PR DESCRIPTION
RHEL 8 ships a different implementation of `mkpasswd` that doesn't support modern hashes.  For ease of use, just containerize `mkpasswd`.

Fixes https://github.com/coreos/fedora-coreos-docs/issues/322.

Corresponding upstream docs in https://github.com/coreos/butane/pull/327.