### PR TITLE
os-extensions: update typo in bash profile for $EDITOR override

### DIFF
--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -57,6 +57,5 @@ storage:
       overwrite: true
       contents:
         inline: |
-          #/bin/sh
           export EDITOR=vim
 ----


### PR DESCRIPTION
I think the intention here was to use `#!/bin/sh` but I don't think
this line is required so let's just delete it.