### PR TITLE
Move asciidoc attributes to antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -14,3 +14,10 @@ start_page: ROOT:index.adoc
 # This lists all the menu definitions of your component.
 nav:
 - modules/ROOT/nav.adoc
+
+asciidoc:
+  attributes:
+    stable-version: 35.20220227.3.0
+    ignition-version: 2.13.0
+    butane-version: 0.14.0
+    coreos-installer-version: 0.13.1

--- a/ci/update-versions.py
+++ b/ci/update-versions.py
@@ -17,7 +17,7 @@ FCOS_STREAMS = {
 
 basedir = os.path.normpath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
 
-with open(os.path.join(basedir, 'site.yml'), 'r+') as fh:
+with open(os.path.join(basedir, 'antora.yml'), 'r+') as fh:
     config = yaml.safe_load(fh)
     attrs = config.setdefault('asciidoc', {}).setdefault('attributes', {})
     orig_attrs = attrs.copy()

--- a/site.yml
+++ b/site.yml
@@ -20,9 +20,3 @@ output:
 runtime:
   fetch: true
   cache_dir: ./cache
-asciidoc:
-  attributes:
-    stable-version: 35.20220227.3.0
-    ignition-version: 2.13.0
-    butane-version: 0.14.0
-    coreos-installer-version: 0.13.1


### PR DESCRIPTION
This should fix the substitution on the Fedora built & hosted version of the docs.