### PR TITLE
provisioning/exoscale: overhaul exoscale documentation

### DIFF
--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -4,73 +4,70 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on https://
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+Before provisioning an FCOS machine, it is recommended to have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
 
 If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and provide an SSH key via the cloud provider and continue from there.
 
 You also need to have access to an Exoscale account. https://portal.exoscale.com/register[Register] if you don't have one.
 
-== About images
+== Uploading an FCOS image as a custom Template
 
-Fedora CoreOS images are periodically updated by Exoscale on their platform. The future goal is to have an Exoscale FCOS link in the  https://getfedora.org/en/coreos/download?tab=cloud_launchable[Cloud Lauchable] section, to be updated at every release.
+NOTE: Exoscale offers official FCOS templates, but they are currently out of date. For now we recommend creating your own template. Track progress on fixing this in https://github.com/coreos/fedora-coreos-tracker/issues/1166[#1166].
 
-== Launching a VM instance (Web Portal)
+Exoscale provides https://community.exoscale.com/documentation/compute/custom-templates[Custom Templates] to be able to upload any cloud image. To create a Custom Template you first need to download and decompress the image.
 
-You can provision a FCOS instance using the Exoscale https://portal.exoscale.com/compute/instances/add?os-group=coreos[Web Portal]. Then you can choose your FCOS version and follow the instance creation wizard.
+.Download and decompress the QCOW2 image with https://github.com/coreos/coreos-installer[coreos-installer]
+[source, bash]
+----
+STREAM="stable"
+coreos-installer download -d -s "${STREAM}" -p exoscale -f qcow2.xz
+----
 
-If you just want SSH access and no further customization, you don't need to pass any custom instance user-data.
-Depending on your Exoscale Organization, relevant SSH public keys will be automatically added to the VM. This provides an easy way to test out FCOS without first creating an Ignition config.
+Alternatively, QCOW2 images can be downloaded from the https://getfedora.org/coreos/download?tab=cloud_operators[download page] and manually decompressed.
 
-If you need to apply any customization, you can provide an Ignition configuration as user-data when creating a new machine instance.
+Next you can https://community.exoscale.com/documentation/compute/custom-templates/#register-a-custom-template[Register a Custom Template]. This can be done from the https://portal.exoscale.com/compute/templates/add[Web Portal] or the https://community.exoscale.com/documentation/tools/exoscale-command-line-interface/[Exoscale CLI]. Either option requires the uncompressed image to be uploaded somewhere public and for the URL and an MD5 checksum to be provided during registration. One option is to use the object storage provided by Exoscale to host the image.
 
-== Launching a VM instance (CLI)
+.Upload to Object Storage and create Custom Template
+[source, bash]
+----
+# Set the version and calcuate the checksum
+FCOS_VERSION='...'
+FILE="fedora-coreos-${FCOS_VERSION}-exoscale.x86_64.qcow2"
+CHECKSUM=$(md5sum $FILE | cut -d " " -f 1)
 
-If you prefer to use a CLI you can provision an FCOS instance using the https://community.exoscale.com/documentation/tools/exoscale-command-line-interface/[Exoscale CLI].
+# Upload to object storage
+BUCKET='newbucket'
+exo storage mb "sos://${BUCKET}"
+exo storage upload --acl public-read $FILE "sos://${BUCKET}/image-import/"
+
+# Create the template using given URL and CHECKSUM
+URL=$(exo storage show "sos://${BUCKET}/image-import/$FILE" --output-template "{{.URL}}")
+TEMPLATE="fedora-coreos-${FCOS_VERSION}"
+exo compute instance-template register --boot-mode=uefi $TEMPLATE $URL $CHECKSUM
+----
+
+You can then view the template using `exo compute instance-template show --visibility=private $TEMPLATE`.
+
+== Launching a VM instance
+
+You can provision a FCOS instance using the Exoscale https://portal.exoscale.com/compute/instances/add[Web Portal] or via the https://community.exoscale.com/documentation/tools/exoscale-command-line-interface/[Exoscale CLI].
 
 .Launching a new instance with Exoscale CLI
 [source, bash]
 ----
-VM_NAME='fcos-node01'
-exo vm create "${VM_NAME}" \
-    --template "Linux Fedora CoreOS 32 64-bit" \
-    --keypair "my_key_name" \
-    --cloud-init-file "path/to/ignition-file.ign" # Optional, if you want to launch a customized FCOS instance.
+NAME='worker'
+TYPE='standard.medium'
+DISK='10' # in GiB
+SSHKEY='mykey'
+TEMPLATE=$TEMPLATE # template name set above
+exo compute instance create $NAME \
+    --disk-size $DISK \
+    --ssh-key $SSHKEY \
+    --template $TEMPLATE \
+    --template-visibility private \
+    --cloud-init "path/to/ignition-file.ign"
 ----
 
-.SSH to the instance
-[source, bash]
-----
-VM_NAME='fcos-node01'
-exo ssh "${VM_NAME}"
-----
+NOTE: If just SSH access is desired and no further customization is required, you don't need to pass any Ignition file and you can omit the `--cloud-init` argument.
 
-== Uploading an FCOS image as a custom Template
-
-Exoscale provides https://community.exoscale.com/documentation/compute/custom-templates[custom Template] to be able to upload any cloud image.
-
-.Download the QCOW2 image with https://github.com/coreos/coreos-installer[coreos-installer]
-[source, bash]
-----
-STREAM="stable"
-coreos-installer download -s "${STREAM}" -p exoscale -f qcow2.xz
-----
-
-Alternatively, QCOW2 images can be manually downloaded from the https://getfedora.org/coreos/download?tab=cloud_operators[download page].
-
-.Uncompress the file
-[source, bash]
-----
-unxz "fedora-coreos-$VERSION-exoscale.x86_64.qcow2.xz"
-----
-
-You need to resize the image virtual size to 10G.
-
-.Resize image virtual size with qemu-img
-[source, bash]
-----
-qemu-img resize "fedora-coreos-$VERSION-exoscale.x86_64.qcow2" +2G
-----
-
-Then you need to https://community.exoscale.com/documentation/compute/custom-templates/#register-a-custom-template[register your custom Template] from the Web Portal or the Exoscale CLI.
-
-Once it is done, you can use it like an official Exoscale Template Image.
+Now you can find the IP address of the instance via `exo compute instance show $NAME` and SSH into the instance. If you didn’t change the defaults, the username is `core` and `ssh core@$IP` should work.


### PR DESCRIPTION
The exoscale CLI had gone through quite a few revisions and old
commands no longer worked. Also the FCOS images that are in Exoscale
are Fedora 34 based. Let's stop referring to the images in Exoscale
and just rely on the Custom Template creation process for our users
for now until we can start publishing the images ourselves.