### PR TITLE
Revert "digitalocean: use --wait instead of polling"

### DIFF
--- a/modules/ROOT/pages/provisioning-digitalocean.adoc
+++ b/modules/ROOT/pages/provisioning-digitalocean.adoc
@@ -21,7 +21,9 @@ Fedora CoreOS is designed to be updated automatically, with different schedules 
 .Example uploading FCOS to a DigitalOcean custom image
 [source, bash]
 ----
-doctl compute image create my-fcos-image --region sfo2 --image-url <download-url> --wait
+doctl compute image create my-fcos-image --region sfo2 --image-url <download-url>
+# Wait for image creation to finish
+while ! doctl compute image list-user | grep my-fcos-image; do sleep 5; done
 ----
 
 === Launching a droplet


### PR DESCRIPTION
`doctl compute image create` doesn't actually support `--wait`.

This reverts commit 993137fc1d706a5dd6560e131c1c0ff053e8616a.