### PR TITLE
Document how to use KubeVirt

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -15,6 +15,7 @@ The currently supported platforms and their identifiers are listed below.
 * DigitalOcean (`digitalocean`): Cloud platform. See xref:provisioning-digitalocean.adoc[Booting on DigitalOcean].
 * Exoscale (`exoscale`): Cloud platform. See xref:provisioning-exoscale.adoc[Booting on Exoscale].
 * Google Cloud Platform (`gcp`): Cloud platform. See xref:provisioning-gcp.adoc[Booting on GCP].
+* KubeVirt (`kubevirt`): Cloud platform. See xref:provisioning-kubevirt.adoc[Booting on KubeVirt].
 * IBM Cloud, VPC Generation 2 (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
 * Bare metal (`metal`): With BIOS, UEFI or network boot, with standard or 4k Native disks. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE].
 * Nutanix (`nutanix`): Hypervisor.

--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -75,3 +75,13 @@ username is `core`.
 ----
 kubectl virt ssh core@my-fcos
 ----
+
+== Mirroring the image for use in private registries
+
+If a private registry in air-gaped installations is used, the image can be mirrored to that registry.
+
+.Mirroring a fcos image from stable stream
+[source, bash]
+----
+skopeo copy docker://quay.io/coreos/fedora-coreos:stable docker://myregistry.io/myorg/fedora-coreos:stable
+----

--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -1,0 +1,77 @@
+= Provisioning Fedora CoreOS on KubeVirt
+
+This guide shows how to provision new Fedora CoreOS (FCOS) nodes on any KubeVirt-enabled Kubernetes cluster.
+
+== Prerequisites
+
+Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+
+You also need to have access to a Kubernetes environment with https://kubevirt.io/user-guide/operations/installation/[KubeVirt] installed.
+
+== Referencing the KubeVirt Image
+
+Fedora CoreOS is designed to be updated automatically, with different schedules per stream.
+
+The image for each stream can directly be referenced from the official registry:
+
+----
+quay.io/coreos/fedora-coreos:{stable|next|testing}
+----
+
+== Launching a VM instance
+
+Now that you have an image it can be used in your VMI definitions. The following example will use the image from the stable stream.
+
+You'll also need the Ignition config.
+Here the Ignition config is exposed to the VMI via a Kubernetes Secret.
+Learn about various ways to expose userdata to VMIs in the https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#startup-scripts[KubeVirt user guide].
+
+.Creating the secret
+[source, bash]
+----
+kubectl create secret generic ignition-payload --from-file=userdata=example.ign
+----
+
+.Launching a VM instance referencing the secret
+[source, bash]
+----
+cat << END > vmi.yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachineInstance
+metadata:
+  name: my-fcos
+spec:
+  domain:
+    devices:
+      disks:
+      - disk:
+          bus: virtio
+        name: containerdisk
+      - disk:
+          bus: virtio
+        name: cloudinitdisk
+      rng: {}
+    resources:
+      requests:
+        memory: 1024M
+  volumes:
+  - containerDisk:
+      image: quay.io/coreos/fedora-coreos:stable
+    name: containerdisk
+  - name: cloudinitdisk
+    cloudInitConfigDrive:
+      secretRef:
+        name: ignition-payload
+END
+kubectl create -f vmi.yaml
+----
+
+Now you should be able to SSH into the instance. If you didn't change the defaults, the
+username is `core`.
+
+.Accessing the VM instance via ssh
+[source, bash]
+----
+kubectl virt ssh core@my-fcos
+----


### PR DESCRIPTION
Document how to get starting with FCOS on kubevirt.

xref https://github.com/coreos/fedora-coreos-tracker/issues/1126

https://pagure.io/fedora-web/websites/pull-request/241 will add KubeVirt to the getfedora page.