### PR TITLE
antora: drop coreos-installer version ✨

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,4 +11,3 @@ asciidoc:
     stable-version: 36.20220522.3.0
     ignition-version: 2.14.0
     butane-version: 0.14.0
-    coreos-installer-version: 0.14.0

--- a/ci/update-versions.py
+++ b/ci/update-versions.py
@@ -9,7 +9,6 @@ import yaml
 GITHUB_RELEASES = {
     'butane-version': 'coreos/butane',
     'ignition-version': 'coreos/ignition',
-    'coreos-installer-version': 'coreos/coreos-installer',
 }
 FCOS_STREAMS = {
     'stable-version': 'stable',


### PR DESCRIPTION
It isn't currently used on the site anywhere.  Drop it to reduce churn.