### PR TITLE
Fix qemu-img backing instructions

### DIFF
--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -45,7 +45,7 @@ qemu-kvm -m 2048 -cpu host -nographic -snapshot \
 .Launching FCOS with QEMU (persistent storage)
 [source, bash]
 ----
-qemu-img create -f qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
+qemu-img create -f qcow2 -F qcow2 -b fedora-coreos-qemu.qcow2 my-fcos-vm.qcow2
 qemu-kvm -m 2048 -cpu host -nographic \
 	-drive if=virtio,file=my-fcos-vm.qcow2 \
 	-fw_cfg name=opt/com.coreos/config,file=path/to/example.ign \


### PR DESCRIPTION
Newer versions of qemu-img need the backing format specified with  the `-F $backingFormat` flag.