### PR TITLE
manual-rollbacks: show full roll-back and roll-forward flows

### DIFF
--- a/modules/ROOT/pages/manual-rollbacks.adoc
+++ b/modules/ROOT/pages/manual-rollbacks.adoc
@@ -8,5 +8,33 @@ To temporarily boot the previous OS deployment, hold down `Shift` during the OS 
 
 == Permanent rollback
 
-To permanently revert to the previous OS deployment, log into the target node, and run `rpm-ostree rollback -r`.
-This operation marks the previous OS deployment as the default, and immediately reboots into it.
+To permanently revert to the previous OS deployment, log into the target node and run the following commands:
+
+[source,bash]
+----
+# Stop the service that performs automatic updates
+sudo systemctl stop zincati.service
+
+# Mark the previous OS deployment as the default, and immediately reboots into it
+sudo rpm-ostree rollback -r
+----
+
+Please note that Zincati will keep looking for updates and upgrade to any new available OS deployment, other than the one you just reverted.
+
+If you prefer to temporarily disable auto-updates and manually re-align to the release stream later on, you can perform the following steps:
+
+[source,bash]
+----
+# Disable Zincati in order to opt-out from future auto-updates
+sudo systemctl disable --now zincati.service
+
+[...]
+
+# At a later point, re-align to the tip of stream and immediately reboot into it
+ARCH="$(arch)"
+STREAM="<YOUR_STREAM>"
+sudo rpm-ostree rebase -r "fedora/${ARCH}/coreos/${STREAM}"
+
+# Re-enable auto-updates
+sudo systemctl enable --now zincati.service
+----

--- a/modules/ROOT/pages/manual-rollbacks.adoc
+++ b/modules/ROOT/pages/manual-rollbacks.adoc
@@ -21,7 +21,7 @@ sudo rpm-ostree rollback -r
 
 Please note that Zincati will keep looking for updates and upgrade to any new available OS deployment, other than the one you just reverted.
 
-If you prefer to temporarily disable auto-updates and manually re-align to the release stream later on, you can perform the following steps:
+If you prefer, you can temporarily turn off auto-updates. Later on, you can re-enable them in order to let the machine catch up with the usual flow of updates:
 
 [source,bash]
 ----
@@ -30,11 +30,6 @@ sudo systemctl disable --now zincati.service
 
 [...]
 
-# At a later point, re-align to the tip of stream and immediately reboot into it
-ARCH="$(arch)"
-STREAM="<YOUR_STREAM>"
-sudo rpm-ostree rebase -r "fedora/${ARCH}/coreos/${STREAM}"
-
-# Re-enable auto-updates
+# At a later point, re-enable it to re-align with the tip of stream
 sudo systemctl enable --now zincati.service
 ----


### PR DESCRIPTION
This expands the section describing permanent rollbacks, in order
to make it more explicit how to deal with auto-updates and to show
how to manually perform roll-forward steps if required.
The scenario came up in a chat thread, and it is good to have the
commands written down for reference.