### PR TITLE
pages: setting a GRUB password

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -37,6 +37,7 @@
 ** xref:alternatives.adoc[Setting alternatives]
 ** xref:counting.adoc[Node counting]
 ** xref:time-zone.adoc[Configuring Time Zone]
+** xref:grub-password.adoc[Setting a GRUB password]
 * OS updates
 ** xref:update-streams.adoc[Update Streams]
 ** xref:auto-updates.adoc[Auto-Updates]

--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -1,0 +1,35 @@
+= Setting a GRUB password
+
+You can setup a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
+
+== Creating the password hash
+
+You can use `grub2-mkpasswd-pbkdf2` to create a password hash for GRUB.
+
+[source, bash]
+----
+$ grub2-mkpasswd-pbkdf2
+Enter password: <PASSWORD>
+Reenter password: <PASSWORD>
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.5AE6255...
+----
+
+NOTE: `grub2-mkpasswd-pbkdf2` tool is a component of the `grub2-tools-minimal` package on Fedora.
+
+== Butane config
+
+With the password hash ready, you can now create the butane config:
+
+[source, yaml]
+----
+variant: fcos
+version: 1.5.0-experimental
+grub:
+  users:
+    - name: root
+      password_hash: grub.pbkdf2.sha512.10000.5AE6255...
+----
+
+The butane config defines a GRUB superuser `root` and sets the password for that user using a hash. At a lower level, this config will generate a `user.cfg` file in `/boot/grub2/` with the necessary GRUB commands to set the given username and password. 
+
+You can now use this config to boot a Fedora CoreOS instance.


### PR DESCRIPTION
We recently landed GRUB password support. Let's add an entry in our docs
that outlines the process of setting up the new functionality.