### PR TITLE
grub-password: remove implementation detail

### DIFF
--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -30,6 +30,6 @@ grub:
       password_hash: grub.pbkdf2.sha512.10000.5AE6255...
 ----
 
-The Butane config defines a GRUB superuser `root` and sets the password for that user using a hash. At a lower level, this config will generate a `user.cfg` file in `/boot/grub2/` with the necessary GRUB commands to set the given username and password. 
+The Butane config defines a GRUB superuser `root` and sets the password for that user using a hash.
 
 You can now use this config to boot a Fedora CoreOS instance.

--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -1,6 +1,6 @@
 = Setting a GRUB password
 
-You can setup a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
+You can set up a password to prevent unauthorized users from accessing the GRUB command line, modifying kernel command-line arguments, or booting non-default OSTree deployments.
 
 == Creating the password hash
 
@@ -18,7 +18,7 @@ NOTE: `grub2-mkpasswd-pbkdf2` tool is a component of the `grub2-tools-minimal` p
 
 == Butane config
 
-With the password hash ready, you can now create the butane config:
+With the password hash ready, you can now create the Butane config:
 
 [source, yaml]
 ----
@@ -30,6 +30,6 @@ grub:
       password_hash: grub.pbkdf2.sha512.10000.5AE6255...
 ----
 
-The butane config defines a GRUB superuser `root` and sets the password for that user using a hash. At a lower level, this config will generate a `user.cfg` file in `/boot/grub2/` with the necessary GRUB commands to set the given username and password. 
+The Butane config defines a GRUB superuser `root` and sets the password for that user using a hash. At a lower level, this config will generate a `user.cfg` file in `/boot/grub2/` with the necessary GRUB commands to set the given username and password. 
 
 You can now use this config to boot a Fedora CoreOS instance.


### PR DESCRIPTION
The point of the sugar is that we don't want users to interact with `user.cfg` directly.  By explicitly stating what's happening under the covers, we're encouraging them to do so.  Anyone who's sufficiently curious can still look at the Butane output.

Followup to #429, where I was too slow on the review.  :eyes: 

cc @saqibali-2k @travier @dustymabe 