### PR TITLE
docs: Remove all overrides for printk

### DIFF
--- a/modules/ROOT/pages/tutorial-autologin.adoc
+++ b/modules/ROOT/pages/tutorial-autologin.adoc
@@ -16,7 +16,6 @@ Let's create a very simple Butane config that will perform the following actions
     - The override will make the service automatically log the `core` user in to the serial console of the booted machine.
 - Set the system hostname by dropping a file at `/etc/hostname`,
 - Add a bash profile that tells systemd to not use a pager for output.
-- Raise kernel console logging level to hide audit messages from the console.
 
 We can create a config file named `autologin.bu` now as:
 
@@ -48,13 +47,6 @@ storage:
         inline: |
           # Tell systemd to not use a pager when printing information
           export SYSTEMD_PAGER=cat
-    - path: /etc/sysctl.d/20-silence-audit.conf
-      mode: 0644
-      contents:
-        inline: |
-          # Raise console message logging level from DEBUG (7) to WARNING (4)
-          # to hide audit messages from the interactive console
-          kernel.printk=4
 ----
 
 This configuration can then be converted into an Ignition config with Butane:
@@ -85,13 +77,6 @@ The resulting Ignition configuration produced by Butane as `autologin.ign` has t
         "path": "/etc/profile.d/systemd-pager.sh",
         "contents": {
           "source": "data:,%23%20Tell%20systemd%20to%20not%20use%20a%20pager%20when%20printing%20information%0Aexport%20SYSTEMD_PAGER%3Dcat%0A"
-        },
-        "mode": 420
-      },
-      {
-        "path": "/etc/sysctl.d/20-silence-audit.conf",
-        "contents": {
-          "source": "data:,%23%20Raise%20console%20message%20logging%20level%20from%20DEBUG%20(7)%20to%20WARNING%20(4)%0A%23%20to%20hide%20audit%20messages%20from%20the%20interactive%20console%0Akernel.printk%3D4%0A"
         },
         "mode": 420
       }

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -4,7 +4,7 @@ NOTE: Make sure that you have completed the steps described in the xref:tutorial
 
 In this tutorial, we will setup SSH access and start a container at boot. Fedora CoreOS is focused on running applications/services in containers thus we recommend trying to run containers and avoid modifying the host directly. Running containers and keeping a pristine host layer makes automatic updates more reliable and allows for separation of concerns with the Fedora CoreOS team responsible for the OS and end-user operators/sysadmins responsible for the applications.
 
-As usual we will setup console autologin, a hostname, systemd pager configuration, and raise kernel logging level, but we will also:
+As usual we will setup console autologin, a hostname, systemd pager configuration, but we will also:
 
 * Add an SSH Key for the `core` user.
 * Add a systemd service (`failure.service`) that fails on boot.
@@ -84,13 +84,6 @@ storage:
         inline: |
           # Tell systemd to not use a pager when printing information
           export SYSTEMD_PAGER=cat
-    - path: /etc/sysctl.d/20-silence-audit.conf
-      mode: 0644
-      contents:
-        inline: |
-          # Raise console message logging level from DEBUG (7) to WARNING (4)
-          # to hide audit messages from the interactive console
-          kernel.printk=4
 ----
 
 TIP: Optionally you can replace the SSH pubkey in the yaml file with your own public key so you can log in to the booted instance. If you choose not to do this you'll still be auto logged in to the serial console.

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -95,13 +95,6 @@ storage:
         inline: |
           # Tell systemd to not use a pager when printing information
           export SYSTEMD_PAGER=cat
-    - path: /etc/sysctl.d/20-silence-audit.conf
-      mode: 0644
-      contents:
-        inline: |
-          # Raise console message logging level from DEBUG (7) to WARNING (4)
-          # to hide audit messages from the interactive console
-          kernel.printk=4
     - path: /usr/local/bin/public-ipv4.sh
       mode: 0755
       contents:

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -44,7 +44,6 @@ mv fedora-coreos-$RELEASE-qemu.x86_64.qcow2 fedora-coreos-older.qcow2
 We will create a Butane config that:
 
 * Sets up console autologin.
-* Raise kernel console logging level to hide audit messages from the console.
 * Add an SSH Key for the `core` user.
 
 Let's write this Butane config to a file called `updates.bu`:
@@ -78,13 +77,6 @@ storage:
         inline: |
           # Tell systemd to not use a pager when printing information
           export SYSTEMD_PAGER=cat
-    - path: /etc/sysctl.d/20-silence-audit.conf
-      mode: 0644
-      contents:
-        inline: |
-          # Raise console message logging level from DEBUG (7) to WARNING (4)
-          # to hide audit messages from the interactive console
-          kernel.printk=4
 ----
 
 TIP: Optionally you can replace the SSH pubkey in the yaml file with your own public key so you can log in to the booted instance. If you choose not to do this you'll still be auto logged in to the serial console.


### PR DESCRIPTION
We effectively do this by default now after
https://github.com/coreos/fedora-coreos-config/pull/1840