### PR TITLE
pages: remove redundant SSH keys entries

### DIFF
--- a/modules/ROOT/pages/hostname.adoc
+++ b/modules/ROOT/pages/hostname.adoc
@@ -6,11 +6,6 @@ To set a custom hostname for your system, use the following Butane config to wri
 ----
 variant: fcos
 version: 1.4.0
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - $pubkey
 storage:
   files:
     - path: /etc/hostname

--- a/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
@@ -8,11 +8,6 @@ The documentation for the config file format lives in the https://github.com/sys
 ----
 variant: fcos
 version: 1.4.0
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - $pubkey
 storage:
   files:
     - path: /etc/systemd/zram-generator.conf

--- a/modules/ROOT/pages/sysconfig-setting-keymap.adoc
+++ b/modules/ROOT/pages/sysconfig-setting-keymap.adoc
@@ -6,11 +6,6 @@ To set your system keymap, use the following Butane config to write to `/etc/vco
 ----
 variant: fcos
 version: 1.4.0
-passwd:
-  users:
-    - name: core
-      ssh_authorized_keys:
-        - $pubkey
 storage:
   files:
     - path: /etc/vconsole.conf


### PR DESCRIPTION
This removes some spurious SSH keys stubs, not relevant to the actual
configuration fragment.