### PR TITLE
Add example for non-root ownership for files & parent directories

### DIFF
--- a/modules/ROOT/pages/managing-files.adoc
+++ b/modules/ROOT/pages/managing-files.adoc
@@ -50,3 +50,33 @@ storage:
       target: /opt/tools/transmogrifier
       hard: false
 ----
+
+.Example for how to set permissions and ownership for a file and its parent directories
+[source,yaml]
+----
+variant: fcos
+version: 1.4.0
+storage:
+  files:
+      # This creates a file, and sets the ownership
+    - path: /home/directory/you/want.txt
+      contents:
+        inline: Hello, world!
+      user:
+        name: exampleuser
+      group:
+        name: examplegroup
+  # This creates the directory that the file should be inside. Its mode is set to 0755 by default, that
+  # is, readable and executable by all, and writable by the owner.
+  directories:
+    - path: /home/directory
+      user:
+        name: exampleuser
+      group:
+        name: examplegroup
+    - path: /home/directory/you
+      user:
+        name: exampleuser
+      group:
+        name: examplegroup
+----

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -58,6 +58,30 @@ storage:
         name: sleeper
       group:
         name: sleeper
+    - path: /home/sleeper/.config/systemd/user/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/systemd/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
   links:
     - path: /home/sleeper/.config/systemd/user/default.target.wants/linger-example.service
       user:
@@ -97,7 +121,31 @@ passwd:
 storage:
   directories:
     - path: /home/sleeper/.config/systemd/user/default.target.wants
-      mode: 0744
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/systemd/user/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/systemd/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/
+      mode: 0755
       user:
         name: sleeper
       group:


### PR DESCRIPTION
managing-files: Add example for non root ownership

Add an example for non root ownership for files
and parent directories

fixes: #441 