### PR TITLE
sysconfig-setting-keymap: prefer the phrase "keyboard layout"

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -29,7 +29,7 @@
 ** xref:running-containers.adoc[Running Containers]
 ** xref:authentication.adoc[Configuring Users and Groups]
 ** xref:hostname.adoc[Setting a Hostname]
-** xref:sysconfig-setting-keymap.adoc[Setting Keymap]
+** xref:sysconfig-setting-keymap.adoc[Setting Keyboard Layout]
 ** xref:os-extensions.adoc[Adding OS extensions]
 ** xref:customize-nic.adoc[How to Customize a NIC Name]
 ** xref:sysconfig-configure-swaponzram.adoc[Configuring SwapOnZRAM]

--- a/modules/ROOT/pages/sysconfig-setting-keymap.adoc
+++ b/modules/ROOT/pages/sysconfig-setting-keymap.adoc
@@ -1,6 +1,6 @@
-= Setting Keymap
+= Setting Keyboard Layout
 
-To set your system keymap, use the following Butane config to write to `/etc/vconsole.conf`:
+To set your system keyboard layout (keymap), use the following Butane config to write to `/etc/vconsole.conf`:
 
 [source,yaml]
 ----


### PR DESCRIPTION
"Keymap" is a bit jargony.  Introduce the subject with the phrase "keyboard layout" instead, but keep the last "keymap" reference because that's what `localectl` calls it.

Fixes https://github.com/coreos/fedora-coreos-docs/issues/454.