### PR TITLE
tutorial: Update systemd user example docs

### DIFF
--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -68,7 +68,7 @@ storage:
       hard: false
 ----
 
-And finally we setup lingering for the systemd user level instance so that it gets started directly on boot and stays running:
+We set up lingering for the systemd user level instance so that it gets started directly on boot and stays running:
 
 [source,yaml]
 ----
@@ -79,6 +79,14 @@ storage:
     - path: /var/lib/systemd/linger/sleeper
       mode: 0644
 ----
+
+The directories
+
+* _/home/sleeper/.config_
+* _/home/sleeper/.config/systemd_
+* _/home/sleeper/.config/systemd/user_
+
+do not exist so they need to be created.
 
 == Writing the Butane config and converting to Ignition
 
@@ -96,8 +104,26 @@ passwd:
     - name: sleeper
 storage:
   directories:
+    - path: /home/sleeper/.config
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/systemd
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
+    - path: /home/sleeper/.config/systemd/user
+      mode: 0755
+      user:
+        name: sleeper
+      group:
+        name: sleeper
     - path: /home/sleeper/.config/systemd/user/default.target.wants
-      mode: 0744
+      mode: 0755
       user:
         name: sleeper
       group:
@@ -106,7 +132,7 @@ storage:
     - path: /var/lib/systemd/linger/sleeper
       mode: 0644
     - path: /home/sleeper/.config/systemd/user/linger-example.service
-      mode: 0755
+      mode: 0644
       contents:
         inline: |
           [Unit]

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -80,13 +80,11 @@ storage:
       mode: 0644
 ----
 
-The directories
+The following directories do not exist yet so they need to be created to tell ignition to set the right ownership and permissions:
 
-* _/home/sleeper/.config_
-* _/home/sleeper/.config/systemd_
-* _/home/sleeper/.config/systemd/user_
-
-do not exist so they need to be created.
+* `/home/sleeper/.config`
+* `/home/sleeper/.config/systemd`
+* `/home/sleeper/.config/systemd/user`
 
 == Writing the Butane config and converting to Ignition
 


### PR DESCRIPTION
Add missing directories to Butane configuration

Adjust file permissions in Butane configuration

Fixes https://github.com/coreos/fedora-coreos-docs/issues/367

A side-note, I created a discussion topic  about what file permissions  the directory _~/.config_ should have:
* https://github.com/containers/podman/discussions/15843

Maybe the group and the world permissions should be removed all together for the files and directories under _~/.config_
?



Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>