### PR TITLE
ibmcloud: update ibmcloud cli provisioning steps

### DIFF
--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -11,7 +11,7 @@ NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS
 If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
 
 You also need to have access to an https://cloud.ibm.com/login[IBM Cloud account]. The examples below use the https://cloud.ibm.com/docs/cli?topic=cli-getting-started[`ibmcloud`] command-line tool, which must be separately installed and configured beforehand.
-Regarding the `ibmcloud` CLI, it is worth noting that it is supported to run the CLI https://cloud.ibm.com/docs/cli?topic=cli-using-idt-from-docker[via a container]. You'll need both the `cloud-object-storage` and `infrastructure-service` plugins installed. This can be done with:
+Folow the directions at https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli to install the ibmcloud CLI. You'll need both the `cloud-object-storage` and `infrastructure-service` plugins installed. This can be done with:
 
  * `ibmcloud plugin install cloud-object-storage`
  * `ibmcloud plugin install infrastructure-service`
@@ -23,6 +23,14 @@ After you've logged in using `ibmcloud login` you can set a target region:
 ----
 REGION='us-east' # run `ibmcloud regions` to view options
 ibmcloud target -r $REGION
+----
+
+.Target a specific resource group
+[source, bash]
+----
+RESOURCE_GROUP='my-resource-group'
+ibmcloud resource group-create ${RESOURCE_GROUP} # Create the resource group if it doesn't exist
+ibmcloud target -g ${RESOURCE_GROUP}
 ----
 
 There are also several other pieces that need to be in place, like a VPC, SSH keys, networks, permissions, etc. Unfortunately, this guide is not a comprehensive IBM Cloud guide. If you are new to IBM Cloud please familiarize yourself using https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started[the documentation for VPC Gen2] first.
@@ -78,7 +86,7 @@ ibmcloud is images --visibility private
 
 Now that you have an image created in your account you can launch a VM instance. You'll have to specify several pieces of information in the command. Embedded in the example below are tips for how to grab that information before launching an instance.
 
-You'll also need the Ignition config you created earlier. Here it is represented in the example command as `@example.ign`, which indicates a file in the current directory named `example.ign`.
+You'll also need the Ignition config you created earlier. Here it is represented in the example command as `@example.ign`, which indicates a file in the current directory named `example.ign`. The @ is required before the path to the ignition file.
 
 .Launching a VM instance
 [source, bash]


### PR DESCRIPTION
Changes addressed in this commit:
- The ibmcloud container link was broken and I could not find the doc anymore so the instructions have been updated to the manual installatin of ibmcloud CLI.

- A resource group is required for creating all the resources necessary to provision a FCOS system.

- I got tripped up on the @ symbol for passing the ignition config. I thought the whole thing was supposed to be replaced with the path to the ignition config but the @ is required before the path. Make it obvious.