### PR TITLE
grub-password: add note about Butane experimental spec

### DIFF
--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -18,7 +18,9 @@ NOTE: `grub2-mkpasswd-pbkdf2` tool is a component of the `grub2-tools-minimal` p
 
 == Butane config
 
-With the password hash ready, you can now create the Butane config:
+With the password hash ready, you can now create the Butane config.
+
+NOTE: The Butane `grub` section requires Butane spec version `1.5.0-experimental`.  After spec 1.5.0 is stabilized, version `1.5.0-experimental` will no longer be accepted by Butane, so Butane configs will need to be updated to replace `1.5.0-experimental` with `1.5.0`.
 
 [source, yaml]
 ----


### PR DESCRIPTION
Based on language removed in 957088d7.