### PR TITLE
grub-password: add missing language about regenerating Ignition configs

### DIFF
--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -20,7 +20,7 @@ NOTE: `grub2-mkpasswd-pbkdf2` tool is a component of the `grub2-tools-minimal` p
 
 With the password hash ready, you can now create the Butane config.
 
-NOTE: The Butane `grub` section requires Butane spec version `1.5.0-experimental`.  After spec 1.5.0 is stabilized, version `1.5.0-experimental` will no longer be accepted by Butane, so Butane configs will need to be updated to replace `1.5.0-experimental` with `1.5.0`.
+NOTE: The Butane `grub` section requires Butane spec version `1.5.0-experimental`.  After spec 1.5.0 is stabilized, version `1.5.0-experimental` will no longer be accepted by Butane, so Butane configs will need to be updated to replace `1.5.0-experimental` with `1.5.0`.  In addition, the corresponding Ignition config version will no longer be accepted by Ignition, so Ignition configs will need to be regenerated with a new version of Butane.
 
 [source, yaml]
 ----


### PR DESCRIPTION
While the GRUB sugar doesn't depend on any new functionality in the experimental Ignition spec, the experimental Butane spec nevertheless specifies the experimental Ignition spec in its output, and this will stop working when the Ignition spec is stabilized.

Fixes #474.