### PR TITLE
Document new-style console configuration

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -136,12 +136,16 @@ For example:
 # Create customized.iso which:
 # - Automatically installs to /dev/sda
 # - Provisions the installed system with config.ign
+# - Configures the installed GRUB and kernel to use a primary graphical
+#   and secondary serial console
 # - Uses network configuration from static-ip.nmconnection
 # - Trusts HTTPS certificates signed by ca.pem
 # - Runs post.sh after installing
 coreos-installer iso customize \
     --dest-device /dev/sda \
     --dest-ignition config.ign \
+    --dest-console ttyS0,115200n8 \
+    --dest-console tty0 \
     --network-keyfile static-ip.nmconnection \
     --ignition-ca ca.pem \
     --post-install post.sh \
@@ -150,6 +154,8 @@ coreos-installer iso customize \
 coreos-installer pxe customize \
     --dest-device /dev/sda \
     --dest-ignition config.ign \
+    --dest-console ttyS0,115200n8 \
+    --dest-console tty0 \
     --network-keyfile static-ip.nmconnection \
     --ignition-ca ca.pem \
     --post-install post.sh \

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -3,54 +3,64 @@
 Sometimes you may want to access the node console to perform troubleshooting steps or emergency maintenance.
 For instance, you may want to access the emergency shell on the console, in order to debug first boot provisioning issues.
 
-== Default console setup
+== Default console configuration
 
-All Fedora CoreOS (FCOS) images come with a default configuration for the console which is meant to accommodate most virtualized and bare-metal setups.
+All Fedora CoreOS (FCOS) images come with a default configuration for the console which is meant to accommodate most virtualized and bare-metal setups. Older FCOS releases enabled both serial and graphical consoles by default. Newer releases use different defaults for each cloud and virtualization platform, and use the kernel's defaults (typically a graphical console) on bare metal. New installs of Fedora CoreOS will switch to these new defaults starting with releases on these dates:
 
-However, it may not always match your specific hardware configuration. In that case, you can tweak the console setup by adjusting kernel parameters.
+- `next` stream: October 3, 2022
+- `testing` stream: November 28, 2022
+- `stable` stream: December 12, 2022
 
-You can specify multiple `console=` options on the kernel command line. Kernel messages will appear on all of them, however only the last-specified device will be used as the foreground interactive console (i.e. `/dev/console`) for the machine.
+The default consoles may not always match your specific hardware configuration. In that case, you can tweak the console setup. Fedora CoreOS has special support for doing this during xref:bare-metal.adoc[bare-metal installation], and in other cases you can xref:kernel-args.adoc[adjust kernel parameters]. Both approaches use https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[kernel argument syntax] for specifying the desired consoles. You can specify multiple consoles; kernel messages will appear on all of them, but only the last-specified device will be used as the foreground interactive console (i.e. `/dev/console`) for the machine.
 
-[NOTE]
-====
-By default these console parameters are provided, in order:
+== Configuring the console during bare-metal installation
 
- - `console=tty0` for VGA.
- - `console=ttyS0,115200n8` for serial console
+If you are installing FCOS via `coreos-installer`, you can configure the console at install time.
 
-The last entry (serial console) is thus used as the interactive console for the machine.
-====
-
-You can remove either console entries in order to match your machine setup, or even remove both and rely on kernel auto-detection (which however may not work for all cases).
-
-== Temporarily tweaking console setup
-
-In order to temporarily change console configuration, it is enough to change kernel arguments in the bootloader for a single boot.
-
-When the GRUB menu shows up initially, press 'e' to edit the current boot entry. Adjust the `console` parameters from the kernel line as described above, then press 'Ctrl-x' to resume booting.
-
-== Configuring console during installation
-
-If you are installing FCOS via `coreos-installer` on a machine which requires custom console configuration, you can permanently configure that directly at install time.
-
+.Example: Enabling primary serial and secondary graphical console
 [source, bash]
 ----
 sudo podman run --pull=always --privileged --rm \
     -v /dev:/dev -v /run/udev:/run/udev -v .:/data -w /data \
     quay.io/coreos/coreos-installer:release \
     install /dev/vdb -i config.ign \
-    --delete-karg 'console=ttyS0,115200n8'
+    --console tty0 --console ttyS0,115200n8
 ----
 
-In the example above, the trailing `--delete-karg 'console=ttyS0,115200n8'` will remove the serial console entry from the boot parameters of the installed system.
+This will configure both the GRUB bootloader and the kernel to use the specified consoles.
 
-== Configuring console after installation
+== Configuring the console with Ignition
 
-If you have an existing FCOS node with a mismatched console configuration, you can permanently adjust that via `rpm-ostree`.
+If you are launching FCOS from an image (in a cloud or a virtual machine), you can use Ignition to configure the console at provisioning time.
 
+.Example: Enabling primary serial and secondary graphical console
+[source,yaml]
+----
+variant: fcos
+version: 1.4.0
+kernel_arguments:
+  should_exist:
+    # Order is significant, so group both arguments into the same list entry.
+    - console=tty0 console=ttyS0,115200n8
+  should_not_exist:
+    # Remove any existing defaults.  Adjust as needed.
+    - console=hvc0
+    - console=tty0
+    - console=ttyAMA0,115200n8
+    - console=ttyS0,115200n8
+    - console=ttyS1,115200n8
+----
+
+This will configure the kernel to use the specified consoles. The GRUB bootloader will continue to use its previous default. Ignition will configure the console, then reboot into the new configuration and continue provisioning the node.
+
+== Configuring the console after installation
+
+You can adjust the console configuration of an existing FCOS node via `rpm-ostree`.
+
+.Example: Enabling primary serial and secondary graphical console
 [source, bash]
 ----
-sudo rpm-ostree kargs --delete 'console=ttyS0,115200n8' --reboot
+sudo rpm-ostree kargs --append=console=tty0 --append=console=ttyS0,115200n8 --reboot
 ----
 
-In the example above, `rpm-ostree` will create a new deployment without the serial console entry, and the machine will reboot into it.
+`rpm-ostree` will create a new deployment with the specified kernel arguments added and reboot into the new configuration. The GRUB bootloader will continue to use its previous default.

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -35,7 +35,7 @@ include::getting-started-libvirt.adoc[]
 
 === Exploring the OS
 
-Once the VM has finished booting, its IP addresses will appear on the serial console. By design, there are no hard-coded default credentials.
+Once the VM has finished booting, its IP addresses will appear on the console. By design, there are no hard-coded default credentials.
 
 If you set up an xref:authentication.adoc[SSH key] for the default `core` user, you can SSH into the VM and explore the OS:
 

--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -32,6 +32,10 @@ kernel_arguments:
     - mitigations=auto,nosmt
 ----
 
+== Modifying Console Configuration During Bare Metal Install
+
+`coreos-installer` has special support for changing the console configuration when performing a bare-metal install. This functionality can be used to add `console` arguments to the kernel command line and equivalent parameters to the GRUB bootloader configuration. For more information, see xref:emergency-shell.adoc[Emergency Console Access]. For more information about bare metal installs, see xref:bare-metal.adoc[Installing CoreOS on Bare Metal].
+
 == Modifying Kernel Arguments on Existing Systems
 
 Kernel arguments changes are managed by `rpm-ostree` via the https://www.mankier.com/1/rpm-ostree[`rpm-ostree kargs`] subcommand. Changes are applied to a new deployment and a reboot is necessary for those to take effect.

--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -38,7 +38,7 @@ Kernel arguments changes are managed by `rpm-ostree` via the https://www.mankier
 
 === Adding kernel arguments
 
-You can append kernel arguments. This is useful with e.g. `console=` that can be used multiple times. An empty value for an argument is allowed:
+You can append kernel arguments. An empty value for an argument is allowed:
 
 [source,bash]
 ----
@@ -63,14 +63,12 @@ You can delete a specific kernel argument key/value pair or an entire argument w
 $ sudo rpm-ostree kargs --delete=KEY=VALUE
 ----
 
-.Example: Remove console parameters to enable kernel auto-detection
+.Example: Re-enable SMT on vulnerable CPUs
 
 [source,bash]
 ----
-$ sudo rpm-ostree kargs --delete 'console=ttyS0,115200n8'
+$ sudo rpm-ostree kargs --delete=mitigations=auto,nosmt
 ----
-
-See also xref:emergency-shell.adoc[Emergency console access].
 
 .Example: Update an existing system from cgroupsv1 to cgroupsv2 and immediately reboot
 

--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -34,7 +34,7 @@ kernel_arguments:
 
 == Modifying Kernel Arguments on Existing Systems
 
-Kernel arguments changes are managed by `rpm-ostree` via the https://www.mankier.com/1/rpm-ostree[`rpm-ostree kargs`] sub command. Changes are applied to a new deployment and a reboot is necessary for those to take effect.
+Kernel arguments changes are managed by `rpm-ostree` via the https://www.mankier.com/1/rpm-ostree[`rpm-ostree kargs`] subcommand. Changes are applied to a new deployment and a reboot is necessary for those to take effect.
 
 === Adding kernel arguments
 

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -109,7 +109,7 @@ virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable 
     --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
 ----
 
-On the serial console you will see:
+On the console you will see:
 
 ----
 Fedora CoreOS 36.20220723.3.1

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -127,7 +127,7 @@ virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable 
     --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
 ----
 
-And view on the serial console that the `Detected Public IPv4` is shown in the serial console output right before you are dropped to a login prompt:
+And view on the console that the `Detected Public IPv4` is shown in the console output right before you are dropped to a login prompt:
 
 ----
 Fedora CoreOS 36.20220723.3.1


### PR DESCRIPTION
Mainly this affects the emergency shell docs.  Also add a section to the kargs page in case a user goes directly to that doc.

Delete the "temporary tweak" section, since it doesn't make sense now.  We previously needed it for removing unwanted console arguments so the booted console would be usable.  Now, with per-platform defaults, the user will likely want to add consoles rather than remove them, but in that case GRUB won't show a menu on the desired console in the first place.

Also stop using `console` as an example on the kargs page.  Manually changing the argument is still valid under some circumstances, but we can switch to a different one to avoid confusing the issue.

Also clean up some references to the serial console in a number of places where the "serial" part is an implementation detail.