### PR TITLE
Fix the issue #489: The command "virt-install" run failed

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -25,10 +25,10 @@ RAM_MB="2048"
 STREAM="stable"
 DISK_GB="10"
 # For x86 / aarch64,
-IGNITION_DEVICE_ARG="--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${IGNITION_CONFIG}""
+IGNITION_DEVICE_ARG=(--qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${IGNITION_CONFIG}")
 
 # For s390x / ppc64le,
-IGNITION_DEVICE_ARG="--disk path=${IGNITION_CONFIG},format=raw,readonly=on,serial=ignition,startup_policy=optional"
+IGNITION_DEVICE_ARG=(--disk path="${IGNITION_CONFIG}",format=raw,readonly=on,serial=ignition,startup_policy=optional)
 
 # Setup the correct SELinux label to allow access to the config
 chcon --verbose --type svirt_home_t ${IGNITION_CONFIG}
@@ -36,7 +36,7 @@ chcon --verbose --type svirt_home_t ${IGNITION_CONFIG}
 virt-install --connect="qemu:///system" --name="${VM_NAME}" --vcpus="${VCPUS}" --memory="${RAM_MB}" \
         --os-variant="fedora-coreos-$STREAM" --import --graphics=none \
         --disk="size=${DISK_GB},backing_store=${IMAGE}" \
-        --network bridge=virbr0 ${IGNITION_DEVICE_ARG}
+        --network bridge=virbr0 "${IGNITION_DEVICE_ARG[@]}"
 ----
 
 NOTE: `virt-install` requires both the OS image and Ignition file to be specified as absolute paths.


### PR DESCRIPTION
Unescaped double quotes in double quotes like `"thisis="content""` will
be interpreted as a string: `thisis=content`, everything works except
that there are spaces in `content`, which leads to *Word Splitting* (man bash). 
In this scenario, it splits the expected one string: `-fw_cfg blablabla` into two
string: `-fw_cfg` and `blablabla`, which indirectly leads to the
"No such file..." error.

Escaped double quotes in double quotes like `"thisis=\"content\""`
will be interpreted as a single quoted string: `'thisis="content"'`,
which is passed to the program that Bash would spawn, the unnecessary
leading single quote will incorrectly parsed as the part of optname,
which is undesirable, in this scenario, `virt-install` will get a
option like `'--qemu-commandline=...'`, which also leads to "invalid
option" error.

As suggested in http://mywiki.wooledge.org/BashFAQ/050, we can employ
Bash's Arrays to work around this issue, as shown in git commit.
