### PR TITLE
workflows: update actions to current major versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run validator
         run: ci/check.py -v

--- a/.github/workflows/update-versions.yml
+++ b/.github/workflows/update-versions.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Update versions
         run: ci/update-versions.py
       - name: Create commit
@@ -26,7 +26,7 @@ jobs:
                   -m "Triggered by update-versions GitHub Action."
           fi
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v3.8.2
+        uses: peter-evans/create-pull-request@v4.2.3
         with:
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
           branch: update-versions


### PR DESCRIPTION
Fixes [deprecation warnings](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for Node.js 12.