### PR TITLE
libvirt.adoc: add note about `DISK_GB`

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -43,6 +43,8 @@ NOTE: `virt-install` requires both the OS image and Ignition file to be specifie
 
 NOTE: Depending on your version of `virt-install`, you may not be able to use `--os-variant=fedora-coreos-*` and will get an error. In this case, you should pick an older Fedora variant (`--os-variant=fedora31` for example). You can find the variants that are supported by you current version of `virt-install` with `osinfo-query os | grep '^\s*fedora'`.
 
+NOTE: `DISK_GB` should be at least as big as the default size of the image. For Fedora CoreOS, this is currently 10 GB.
+
 TIP: Make sure that your user has access to `/dev/kvm`. The default is to allow access for everyone, but on some distributions you may need to add yourself to the `kvm` group.
 
 TIP: You can escape out of the serial console by pressing `CTRL + ]`.


### PR DESCRIPTION
NOTE: `DISK_GB` should be >= OS image size, if failed to boot with `dev-disk-by\x2dlabel-boot.device: Job dev-disk-by\x2dlabel-boot. device/start timed out.`, when you get emergency shell, run `sgdisk -p /dev/vda` to check the partition table.