### PR TITLE
ssh & systemd: hint at file embedding instead of inlining

### DIFF
--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -20,7 +20,7 @@ passwd:
     - name: miabbott
 ----
 
-You will typically want to configure SSH keys or a password, in order to be able to login as those users.
+You will typically want to configure SSH keys or a password, in order to be able to log in as those users.
 
 == Using an SSH Key
 
@@ -38,22 +38,60 @@ passwd:
     - name: jlebon
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
-        - sh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
     - name: miabbott
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTey7R...
 ----
 
+=== Using File References to SSH Keys
+
+Depending on the configuration variant and version you use, you can use local file references to SSH public keys instead
+of inlining them.
+The example from the xref:#_using_an_ssh_key[previous section] can thus be rewritten as follows:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.5.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys_local:
+        - users/core/id_rsa.pub
+    - name: jlebon
+      ssh_authorized_keys_local:
+        - users/jlebon/id_rsa.pub
+        - users/jlebon/id_ed25519.pub
+    - name: miabbott
+      ssh_authorized_keys_local:
+        - users/miabbott/id_rsa.pub
+----
+
+You have to use `butane` with the `--files-dir` parameter to allow loading files from disk when converting to Ignition configurations for this to work.
+
+NOTE: Check the https://coreos.github.io/butane/specs/[Configuration specifications] for more details and which versions
+of your selected variant support it. Generally, each file may contain multiple SSH keys, one per line, and you may
+additionally specify inline `ssh_authorized_keys` as well as long as the SSH keys are unique.
+
 === SSH Key Locations
 
-sshd uses a https://github.com/coreos/ssh-key-dir[helper program] to read public keys from files in a user's `~/.ssh/authorized_keys.d` directory. Key files are read in alphabetical order, ignoring dotfiles. The standard `~/.ssh/authorized_keys` file is read afterward, in the usual way. To debug the reading of `~/.ssh/authorized_keys.d`, manually run the helper program and inspect its output:
+https://man.openbsd.org/sshd_config[sshd] uses a https://github.com/coreos/ssh-key-dir[helper program], specified via
+the `AuthorizedKeysCommand` directive, to read public keys from files in a user's `~/.ssh/authorized_keys.d` directory.
+The `AuthorizedKeysCommand` is tried after the usual `AuthorizedKeysFile` files (defaulting to `~/.ssh/authorized_keys`)
+and will not be executed if a matching key is found there. Key files in `~/.ssh/authorized_keys.d` are read in
+alphabetical order, ignoring dotfiles.
+
+Ignition writes configured SSH keys to `~/.ssh/authorized_keys.d/ignition`. On platforms where SSH keys can be configured at the platform level, such as AWS, Afterburn writes those keys to `~/.ssh/authorized_keys.d/afterburn`.
+
+To debug the reading of `~/.ssh/authorized_keys.d`, manually run the helper program and inspect its output:
 
 [source,bash]
 ----
 /usr/libexec/ssh-key-dir
 ----
 
-Ignition writes configured SSH keys to `~/.ssh/authorized_keys.d/ignition`. On platforms where SSH keys can be configured at the platform level, such as AWS, Afterburn writes those keys to `~/.ssh/authorized_keys.d/afterburn`.
+To view and validate the effective configuration for sshd, two test modes (`-t`, `-T`) are available as documented on the https://man.openbsd.org/sshd[manual pages].
 
 == Using Password Authentication
 
@@ -71,7 +109,7 @@ passwd:
     - name: jlebon
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
-        - sh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
     - name: miabbott
       password_hash: $y$j9T$aUmgEDoFIDPhGxEe2FUjc/$C5A...
       ssh_authorized_keys:
@@ -111,7 +149,7 @@ passwd:
         - wheel
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
-        - sh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
     - name: miabbott
       groups:
         - docker
@@ -142,7 +180,7 @@ passwd:
         - wheel
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
-        - sh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
     - name: miabbott
       groups:
         - docker
@@ -177,7 +215,7 @@ passwd:
         - sudo
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDC5QFS...
-        - sh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIveEaMRW...
     - name: miabbott
       groups:
         - docker

--- a/modules/ROOT/pages/proxy.adoc
+++ b/modules/ROOT/pages/proxy.adoc
@@ -30,6 +30,8 @@ storage:
 
 https://github.com/coreos/zincati[Zincati] polls for OS updates, and https://github.com/coreos/rpm-ostree[rpm-ostree] is used to apply OS and layered package updates both therefore requiring internet access. The optional anonymized https://docs.fedoraproject.org/en-US/fedora-coreos/counting/[countme] service also requires access if enabled.
 
+TIP: You may be able to use local file references to systemd units instead of inlining them. See xref:tutorial-services.adoc#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
+
 [source,yaml]
 ----
 variant: fcos

--- a/modules/ROOT/pages/running-containers.adoc
+++ b/modules/ROOT/pages/running-containers.adoc
@@ -6,6 +6,8 @@ Fedora CoreOS ships with both the `docker` CLI tool (as provided via https://mob
 == Example configuration
 The following Butane config snippet configures the systemd `hello.service` to run https://www.busybox.net[busybox].
 
+TIP: You may be able to use local file references to systemd units instead of inlining them. See xref:tutorial-services.adoc#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
+
 .Example for running busybox using systemd and podman
 [source,yaml]
 ----

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -14,6 +14,8 @@ As usual, we will set up console autologin, a hostname, systemd pager configurat
 
 Similarly to what we did in the second provisioning scenario, we will write the following Butane config in a file called `containers.bu`:
 
+TIP: Optionally, you can replace the SSH public key in the yaml file with your own public key so you can log in to the booted instance remotely. If you choose not to do this you'll still be auto logged in to the serial console.
+
 .Example with automatic serial console login, SSH key, and multiple systemd units
 [source,yaml]
 ----
@@ -87,7 +89,7 @@ storage:
           export SYSTEMD_PAGER=cat
 ----
 
-TIP: Optionally you can replace the SSH pubkey in the yaml file with your own public key so you can log in to the booted instance. If you choose not to do this you'll still be auto logged in to the serial console.
+TIP: You may be able to use local file references to systemd units and SSH public keys instead of inlining them. See xref:authentication.adoc#_using_file_references_to_ssh_keys[Using File References to SSH Keys] and xref:tutorial-services.adoc#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
 
 Run Butane to convert that to an Ignition config:
 

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -104,11 +104,62 @@ storage:
               /etc/issue.d/50_public-ipv4.issue
 ----
 
+TIP: You may be able to use local file references to systemd units instead of inlining them. See xref:#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
+
 And then convert to Ignition:
 
 [source,bash]
 ----
 butane --pretty --strict services.bu --output services.ign
+----
+
+=== Using butane's `--files-dir` Parameter to Embed Files
+
+Depending on the variant and version you use, you can use local file references to systemd units instead of inlining them.
+The example from the xref:#_writing_the_butane_config_and_converting_to_ignition[previous section] can thus be rewritten as follows:
+
+[source,yaml]
+----
+variant: fcos
+version: 1.5.0
+systemd:
+  units:
+    - name: serial-getty@ttyS0.service
+      dropins:
+      - name: autologin-core.conf
+        contents_local: systemd/autologin-core.conf
+    - name: issuegen-public-ipv4.service
+      enabled: true
+      contents_local: systemd/issuegen-public-ipv4.service
+storage:
+  files:
+    - path: /etc/hostname
+      mode: 0644
+      contents:
+        inline: |
+          tutorial
+    - path: /etc/profile.d/systemd-pager.sh
+      mode: 0644
+      contents:
+        inline: |
+          # Tell systemd to not use a pager when printing information
+          export SYSTEMD_PAGER=cat
+    - path: /usr/local/bin/public-ipv4.sh
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          echo "Detected Public IPv4: is $(curl https://ipv4.icanhazip.com)" > \
+              /etc/issue.d/50_public-ipv4.issue
+----
+
+NOTE: Check the https://coreos.github.io/butane/specs/[Configuration specifications] for more details and which versions of your selected variant support it.
+
+And then convert to Ignition (assuming the files (`autologin-core.conf` and `issuegen-public-ipv4.service`) are in a directory called `systemd` in your current working directory):
+
+[source,bash]
+----
+butane --pretty --strict --files-dir="./systemd"  services.bu --output services.ign
 ----
 
 == Testing


### PR DESCRIPTION
With butane 0.18.0 and the correct variants and versions file embedding of SSH keys and systemd (dropins) is possible.

Fixes #511

---

First stab at this. I am not entirely happy about the systemd situation. There is no clear & good place that I could identify where to provide good details (vs. the dedicated authentication document for SSH) besides a tutorial or two dedicated to a particular _thing_ (instead of the overall options). This strikes me as something that could be generally improved. Thoughts?