### PR TITLE
provisioning/vmware: showcase ability to use file references with govc

### DIFF
--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -50,7 +50,25 @@ CONFIG_ENCODING='gzip+base64'
 CONFIG_ENCODED=$(cat example.ign | gzip -9 | base64 -w0 -)
 ----
 
-If your generated Ignition configuration is still too large, you will encounter an `Argument list too long` error or similar. The last resort is to use a configuration file. Instead of setting an environment variable containing your Ignition configuration, create an `ovftool` compatible configuration file in the directory you are invoking from like so:
+If your generated Ignition configuration is still too large, you will encounter an `Argument list too long` error or similar. The solution to that problem depends on whether you are working with vSphere or Workstation/Fusion.
+
+For vSphere the solution is simple because instead of inlining the configuration file within your shell, `govc` allows you to specify a path to a local file instead with the https://github.com/vmware/govmomi/blob/main/govc/USAGE.md#vmchange[`vm.change`]-command and will handle reading and writing it internally, circumventing any shell limitations.
+
+[source, bash]
+----
+CONFIG_ENCODING="gzip+base64"
+CONFIG_FILE="example.ign"
+CONFIG_FILE_ENCODED="${CONFIG_FILE}.gzip.b64"
+
+gzip -9c "${CONFIG_FILE}" | base64 -w0 - > "${CONFIG_FILE_ENCODED}"
+
+govc vm.change -vm "${VM_NAME}" -e "guestinfo.ignition.config.data.encoding=${CONFIG_ENCODING}"
+govc vm.change -vm "${VM_NAME}" -f "guestinfo.ignition.config.data=${CONFIG_FILE_ENCODED}" # using `-f` with a file path instead of `-e`
+----
+
+NOTE: Using `gzip` for this solution is optional and primarily used for consistent examples.
+
+In the case of Workstation/Fusion, or as a last resort in general, there is the option to use a configuration file. Instead of setting an environment variable containing your Ignition configuration, create an `ovftool` compatible configuration file in the directory you are invoking from like so:
 
 [source, bash]
 ----


### PR DESCRIPTION
As discussed in #517 there is another option when dealing with vSphere and govc to provide large Ignition configs by providing a file reference.

CC: @deed02392 