### PR TITLE
adoc: clear explanation of cloud platform scope

### DIFF
--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -15,7 +15,7 @@ The currently supported platforms and their identifiers are listed below.
 * DigitalOcean (`digitalocean`): Cloud platform. See xref:provisioning-digitalocean.adoc[Booting on DigitalOcean].
 * Exoscale (`exoscale`): Cloud platform. See xref:provisioning-exoscale.adoc[Booting on Exoscale].
 * Google Cloud Platform (`gcp`): Cloud platform. See xref:provisioning-gcp.adoc[Booting on GCP].
-* IBM Cloud, VPC Generation 2 (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
+* IBM Cloud (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
 * Bare metal (`metal`): With BIOS, UEFI or network boot, with standard or 4k Native disks. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE].
 * Nutanix (`nutanix`): Hypervisor.
 * OpenStack (cloud platform): `openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
@@ -23,6 +23,12 @@ The currently supported platforms and their identifiers are listed below.
 * VirtualBox ('virtualbox'): Hypervisor. See xref:provisioning-virtualbox.adoc[Booting on VirtualBox].
 * VMware ESXi, Fusion, and Workstation (`vmware`): Hypervisor. See xref:provisioning-vmware.adoc[Booting on VMware]. Fedora CoreOS images currently use https://kb.vmware.com/s/article/1003746[hardware version] 17, supporting VMware ESXi 7.0 or later, Fusion 12.0 or later, and Workstation 16.0 or later.
 * Vultr (`vultr`): Cloud platform. See xref:provisioning-vultr.adoc[Booting on Vultr].
+
+NOTE: The supported cloud platforms do not include previous generation of cloud platform services, such as:
+- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment] and https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances].
+- https://cloud.google.com/vpc/docs/legacy[Google Cloud Legacy Networks].
+- https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment] and https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)] using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)].
+- https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models[Azure Service Manager (ASM) control plane environment] and https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation[Azure IaaS VM (Classic)] or Hyper-V Gen1 format using https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic[Azure VNET (Classic)].
 
 === AArch64
 
@@ -33,7 +39,7 @@ The currently supported platforms and their identifiers are listed below.
 
 === s390x
 
-* IBM Cloud, VPC Generation 2 (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
+* IBM Cloud (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
 * Bare metal (`metal`): From disk or network boot. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE].
 * QEMU (`qemu`): Hypervisor. See xref:provisioning-libvirt.adoc[Booting on libvirt]
 * OpenStack (cloud platform): `openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].

--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -24,7 +24,8 @@ The currently supported platforms and their identifiers are listed below.
 * VMware ESXi, Fusion, and Workstation (`vmware`): Hypervisor. See xref:provisioning-vmware.adoc[Booting on VMware]. Fedora CoreOS images currently use https://kb.vmware.com/s/article/1003746[hardware version] 17, supporting VMware ESXi 7.0 or later, Fusion 12.0 or later, and Workstation 16.0 or later.
 * Vultr (`vultr`): Cloud platform. See xref:provisioning-vultr.adoc[Booting on Vultr].
 
-NOTE: The supported cloud platforms do not include previous generation of cloud platform services, such as:
+Important note: The supported cloud platforms do not include previous generation of cloud platform services, such as:
+
 - https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment] and https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances].
 - https://cloud.google.com/vpc/docs/legacy[Google Cloud Legacy Networks].
 - https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment] and https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)] using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)].

--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -24,13 +24,6 @@ The currently supported platforms and their identifiers are listed below.
 * VMware ESXi, Fusion, and Workstation (`vmware`): Hypervisor. See xref:provisioning-vmware.adoc[Booting on VMware]. Fedora CoreOS images currently use https://kb.vmware.com/s/article/1003746[hardware version] 17, supporting VMware ESXi 7.0 or later, Fusion 12.0 or later, and Workstation 16.0 or later.
 * Vultr (`vultr`): Cloud platform. See xref:provisioning-vultr.adoc[Booting on Vultr].
 
-Important note: The supported cloud platforms do not include previous generation of cloud platform services, such as:
-
-- https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment] and https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances].
-- https://cloud.google.com/vpc/docs/legacy[Google Cloud Legacy Networks].
-- https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment] and https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)] using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)].
-- https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models[Azure Service Manager (ASM) control plane environment] and https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation[Azure IaaS VM (Classic)] or Hyper-V Gen1 format using https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic[Azure VNET (Classic)].
-
 === AArch64
 
 * Amazon Web Services (`aws`): Cloud platform. See xref:provisioning-aws.adoc[Booting on AWS].

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -2,7 +2,7 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances on the Amazon Web Services (AWS) cloud platform.
 
-NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances], within the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment].
+NOTE: Fedora CoreOS (FCOS) is not supported with https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances], within the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment].
 
 == Prerequisites
 

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -2,6 +2,8 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances on the Amazon Web Services (AWS) cloud platform.
 
+NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://aws.amazon.com/ec2/previous-generation/[Amazon EC2 Previous Generation Instances], within the https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html[AWS EC2-Classic Networking environment].
+
 == Prerequisites
 
 Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -2,6 +2,8 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Azure. Fedora currently does not publish Fedora CoreOS images within Azure, so you must download an Azure image from Fedora and upload it to your Azure subscription.
 
+NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation[Azure IaaS VM (Classic)] or Hyper-V Gen1 format, using https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic[Azure VNET (Classic)] within the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models[Azure Service Manager (ASM) control plane environment].
+
 == Prerequisites
 
 Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -2,7 +2,7 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Azure. Fedora currently does not publish Fedora CoreOS images within Azure, so you must download an Azure image from Fedora and upload it to your Azure subscription.
 
-NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation[Azure IaaS VM (Classic)] or Hyper-V Gen1 format, using https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic[Azure VNET (Classic)] within the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models[Azure Service Manager (ASM) control plane environment].
+NOTE: Fedora CoreOS (FCOS) is not supported with https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation[Azure IaaS VM (Classic)] or Hyper-V Gen1 format, using https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic[Azure VNET (Classic)] within the https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models[Azure Service Manager (ASM) control plane environment].
 
 == Prerequisites
 

--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -2,8 +2,6 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances on Google Cloud Platform (GCP).
 
-NOTE: This guide does not describe Fedora CoreOS (FCOS) with previous generation of Google Cloud services such as https://cloud.google.com/vpc/docs/legacy[Google Cloud Legacy Networks].
-
 == Prerequisites
 
 Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].

--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -2,6 +2,8 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances on Google Cloud Platform (GCP).
 
+NOTE: This guide does not describe Fedora CoreOS (FCOS) with previous generation of Google Cloud services such as https://cloud.google.com/vpc/docs/legacy[Google Cloud Legacy Networks].
+
 == Prerequisites
 
 Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -1,6 +1,8 @@
 = Provisioning Fedora CoreOS on IBM Cloud
 
-This guide shows how to provision new Fedora CoreOS (FCOS) instances in IBM Cloud VPC Generation 2 for either the `x86_64` or `s390x` architectures.
+This guide shows how to provision new Fedora CoreOS (FCOS) instances in IBM Cloud for either the `x86_64` or `s390x` architectures.
+
+NOTE: This guide describes IBM Cloud infrastructure services, specifically IBM Cloud Virtual Servers using VPC networking (also known as IBM Cloud VPC Infrastructure environment). It does not describe IBM Cloud Virtual Server (Classic), using the IBM Cloud Classic Infrastructure environment.
 
 == Prerequisites
 
@@ -33,7 +35,7 @@ ibmcloud resource group-create $RESOURCE_GROUP # Create the resource group if it
 ibmcloud target -g $RESOURCE_GROUP
 ----
 
-There are also several other pieces that need to be in place, like a VPC, SSH keys, networks, permissions, etc. Unfortunately, this guide is not a comprehensive IBM Cloud guide. If you are new to IBM Cloud please familiarize yourself using https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started[the documentation for VPC Gen2] first.
+There are also several other pieces that need to be in place, like a VPC, SSH keys, networks, permissions, etc. Unfortunately, this guide is not a comprehensive IBM Cloud guide. If you are new to IBM Cloud please familiarize yourself using https://cloud.ibm.com/docs/vpc?topic=vpc-getting-started[the documentation for IBM Cloud VPC networks and related infrastructure services] first.
 
 === Creating an Image
 

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -2,7 +2,7 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances in IBM Cloud for either the `x86_64` or `s390x` architectures.
 
-NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)], using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)] within the https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment]. The guide exclusively refers to Fedora CoreOS (FCOS) with IBM Cloud infrastructure services, also known as IBM Cloud VPC Infrastructure environment.
+NOTE: Fedora CoreOS (FCOS) is not supported with https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)], using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)] within the https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment]. The guide exclusively refers to Fedora CoreOS (FCOS) with IBM Cloud infrastructure services, also known as IBM Cloud VPC Infrastructure environment.
 
 == Prerequisites
 

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -2,7 +2,7 @@
 
 This guide shows how to provision new Fedora CoreOS (FCOS) instances in IBM Cloud for either the `x86_64` or `s390x` architectures.
 
-NOTE: This guide describes IBM Cloud infrastructure services, specifically IBM Cloud Virtual Servers using VPC networking (also known as IBM Cloud VPC Infrastructure environment). It does not describe IBM Cloud Virtual Server (Classic), using the IBM Cloud Classic Infrastructure environment.
+NOTE: This guide does not describe Fedora CoreOS (FCOS) with https://cloud.ibm.com/docs/virtual-servers[IBM Cloud Virtual Servers (Classic)], using https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans[IBM Cloud VLAN (Classic) and VLAN Subnets (Classic)] within the https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure[IBM Cloud Classic Infrastructure environment]. The guide exclusively refers to Fedora CoreOS (FCOS) with IBM Cloud infrastructure services, also known as IBM Cloud VPC Infrastructure environment.
 
 == Prerequisites
 


### PR DESCRIPTION
For distinction, it is important to note that each hyperscaler Cloud Service Provider has some previous generation of Cloud Services and Networking environments. Misleading labels may cause confusion with end users, particularly as most Cloud Platforms have hardware generations for different Virtual Machines and Bare Metals using newer CPU and DRAM.

Below is the evidence for Cloud Service Provider versioning, where most products have suffix (Classic).

The PR includes an abbreviated version of the below content.


### AWS hyperscaler, Cloud Service Provider

- AWS EC2-Classic Networking environment (replaced by VPC networks environment). Deprecated in Aug-2022. See [AWS EC2-Classic documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-classic-platform.html).
- Amazon EC2 Previous Generation Instances. See [AWS EC2 Previous Generation Instances documentation](https://aws.amazon.com/ec2/previous-generation/).

### Google Cloud hyperscaler, Cloud Service Provider

- Google Cloud Legacy Networks (replaced by VPC Networks). Not available to provision. See [Google Cloud Legacy Networks documentation](https://cloud.google.com/vpc/docs/legacy).

### IBM Cloud hyperscaler, Cloud Service Provider

- IBM Cloud Classic Infrastructure environment, replaced by IBM Cloud VPC Infrastructure environment. See [IBM Cloud Classic Infrastructure compared with IBM Cloud VPC Infrastructure environments documentation](https://cloud.ibm.com/docs/cloud-infrastructure?topic=cloud-infrastructure-compare-infrastructure).
    - IBM Cloud Virtual Servers (Classic) based on Xen hypervisor; replaced by IBM Cloud Virtual Servers (with hardware generations) based on KVM hypervisor. See [IBM Cloud Virtual Servers (for Classic) documentation](https://cloud.ibm.com/docs/virtual-servers).
    - IBM Cloud VLAN (Classic) and VLAN Subnets (Classic); replaced by IBM Cloud VPC Networks and IBM Cloud VPC Subnets. See [IBM Cloud Classic VLANs documentation](https://cloud.ibm.com/docs/vlans?topic=vlans-about-vlans).


### Microsoft Azure hyperscaler, Cloud Service Provider

- Azure Service Manager (ASM) control plane (aka. environment), replaced by Azure Resource Manager (ARM) control plane.
    - Azure IaaS VM (Classic), managed by Azure Service Manager (ASM) control plane. Deprecation due Sept-2023. See [Azure Classic VM deprecation documentation](https://learn.microsoft.com/en-us/azure//virtual-machines/classic-vm-deprecation) and [Azure Resource Manager vs. Classic deployment models documentation](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/deployment-models).
        - Azure IaaS VM using Hyper-V Generation 1 format; replaced by Hyper-V Generation 2 format. See [Azure Classic VM API reference without Generation 2 support](https://learn.microsoft.com/en-us/previous-versions/azure/reference/jj157194(v=azure.100)) compared with [Azure VM API reference with Generation 2 support](https://learn.microsoft.com/en-us/rest/api/compute/virtual-machines/create-or-update?tabs=HTTP).
    - Azure VNet (Classic), part of the Azure Cloud Services (Classic). Deprecation due Aug-2024. See [Azure Classic VNet documentation](https://learn.microsoft.com/en-us/previous-versions/azure/virtual-network/create-virtual-network-classic) and [Azure Cloud Services (Classic) documentation](https://learn.microsoft.com/en-us/azure/cloud-services/).
    - Azure Storage Accounts (Classic), part of the Azure Cloud Services (Classic). Deprecation due Aug-2024. See [Azure Classic Storage Account migration documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-migrate-classic) and [Azure Cloud Services (Classic) documentation](https://learn.microsoft.com/en-us/azure/cloud-services/).