### PR TITLE
Use `--output` option instead of stdout redirect

### DIFF
--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -213,3 +213,5 @@ butane --pretty --strict example.bu > example.ign
 ----
 +
 . Use the `example.ign` file to xref:getting-started.adoc[boot Fedora CoreOS].
+
+NOTE: If using Butane on Windows, `> example.ign` will create an UTF-16 encoded Ignition file. This can prevent Fedora CoreOS from booting properly. Use `--output example.ign` instead.


### PR DESCRIPTION
On windows the redirect operator `>` creates an utf-16 encoded ignition file.
This change avoids the issue https://github.com/coreos/butane/issues/293.