### PR TITLE
KubeVirt doc: Fix image link

### DIFF
--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -59,7 +59,7 @@ spec:
         memory: 2048M
   volumes:
   - containerDisk:
-      image: quay.io/coreos/fedora-coreos:${STREAM}
+      image: quay.io/fedora/fedora-coreos-kubevirt:${STREAM}
     name: containerdisk
   - name: cloudinitdisk
     cloudInitConfigDrive:


### PR DESCRIPTION
Quick fix up of the `quay.io/fedora/fedora-coreos-kubevirt` image link in the `provisioning-kubevirt` document.