### PR TITLE
The download page is now under fedoraproject.org

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -16,7 +16,7 @@ NOTE: If you have servers with different types and/or number of hard drives, you
 
 To install FCOS onto bare metal using the live ISO interactively, follow these steps:
 
-- Download the latest ISO image from the https://getfedora.org/coreos/download?tab=metal_virtualized&stream=stable[download page] or with podman (see https://coreos.github.io/coreos-installer/cmd/download/[documentation] for options):
+- Download the latest ISO image from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[download page] or with podman (see https://coreos.github.io/coreos-installer/cmd/download/[documentation] for options):
 [source, bash]
 ----
 podman run --security-opt label=disable --pull=always --rm -v .:/data -w /data \
@@ -113,7 +113,7 @@ In this example, `coreos-installer` will download the latest stable FCOS metal i
 
 == Downloading and mirroring the metal image
 
-Sometimes, it's necessary to download the metal image ahead of time and then have it passed locally to `coreos-installer` for installation. You can download the metal image directly from the https://getfedora.org/en/coreos/download?tab=metal_virtualized[FCOS download page], or you can use `coreos-installer download`.
+Sometimes, it's necessary to download the metal image ahead of time and then have it passed locally to `coreos-installer` for installation. You can download the metal image directly from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[FCOS download page], or you can use `coreos-installer download`.
 
 TIP: When installing via the live ISO or PXE, there is no need to download the metal image. It is already part of those environments.
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -73,12 +73,11 @@ https://discussion.fedoraproject.org/t/launch-faq-what-happens-to-project-atomic
 
 We have the following new communication channels around Fedora CoreOS:
 
-* mailing list:
-https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[coreos@lists.fedoraproject.org]
+* mailing list: https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[coreos@lists.fedoraproject.org]
 * operational notices for Fedora CoreOS: https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/[coreos-status@lists.fedoraproject.org]
 * IRC: link:ircs://irc.libera.chat:6697/#fedora-coreos[#fedora-coreos on Libera.Chat]
-* forum at https://discussion.fedoraproject.org/c/server/coreos/5
-* website at https://getfedora.org/coreos/
+* forum at https://discussion.fedoraproject.org/tag/coreos
+* website at https://fedoraproject.org/coreos/
 * Twitter at https://twitter.com/fedoracoreos[@fedoracoreos] (Fedora CoreOS news), https://twitter.com/fedora[@fedora] (all Fedora and other relevant news)
 
 There is a community meeting that happens every week. See the https://calendar.fedoraproject.org/CoreOS/[Fedora CoreOS fedocal] for the most up-to-date information.
@@ -91,7 +90,7 @@ https://discussion.fedoraproject.org/t/launch-faq-what-are-the-communication-cha
 
 === Where can I download Fedora CoreOS?
 
-Fedora CoreOS artifacts are available at https://getfedora.org/en/coreos/download/[getfedora.org].
+Fedora CoreOS artifacts are available at https://fedoraproject.org/en/coreos/download/[fedoraproject.org].
 
 https://discussion.fedoraproject.org/t/launch-faq-where-can-i-download-fedora-coreos/47/1[Discuss on discussion.fedoraproject.org]
 

--- a/modules/ROOT/pages/getting-started-aws.adoc
+++ b/modules/ROOT/pages/getting-started-aws.adoc
@@ -1,6 +1,6 @@
 :page-partial:
 
-New AWS instances can be directly created from the public FCOS images. You can find the latest AMI for each region from the https://getfedora.org/coreos/download/[download page].
+New AWS instances can be directly created from the public FCOS images. You can find the latest AMI for each region from the https://fedoraproject.org/coreos/download/[download page].
 
 If you are only interested in exploring FCOS without further customization, you can use a https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html[registered SSH key-pair] for the default `core` user.
 

--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -1,6 +1,6 @@
 :page-partial:
 
-. Fetch the latest image suitable for the `qemu` platform using `coreos-installer` (or https://getfedora.org/coreos/download/[download and verify] it from the web). You can use `coreos-installer` https://quay.io/repository/coreos/coreos-installer[as a container], or on Fedora install it from the repos.
+. Fetch the latest image suitable for the `qemu` platform using `coreos-installer` (or https://fedoraproject.org/coreos/download/[download and verify] it from the web). You can use `coreos-installer` https://quay.io/repository/coreos/coreos-installer[as a container], or on Fedora install it from the repos.
 +
 [source, bash]
 ----

--- a/modules/ROOT/pages/migrate-cl.adoc
+++ b/modules/ROOT/pages/migrate-cl.adoc
@@ -14,7 +14,7 @@ The following changes have been made to the installation process:
 
 * The `coreos-install` script has been replaced with https://github.com/coreos/coreos-installer[`coreos-installer`]. It offers similar functionality.
 * The `coreos.autologin` kernel command-line parameter is not currently supported in FCOS. For access recovery purposes, there are instructions available xref:access-recovery.adoc[here].
-* Certain CL platforms, such as Vagrant, are not yet supported in FCOS. Refer to the https://getfedora.org/coreos/download/[Download page] to see the available image types.
+* Certain CL platforms, such as Vagrant, are not yet supported in FCOS. Refer to the https://fedoraproject.org/coreos/download/[Download page] to see the available image types.
 
 == Software package changes
 

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -118,7 +118,7 @@ winget install --id Fedora.CoreOS.butane
 ==== Linux
 To use the Butane binary on Linux, follow these steps:
 
-. If you have not already done so, download the https://getfedora.org/security/[Fedora signing keys] and import them:
+. If you have not already done so, download the https://fedoraproject.org/security/[Fedora signing keys] and import them:
 +
 [source,bash]
 ----

--- a/modules/ROOT/pages/provisioning-aliyun.adoc
+++ b/modules/ROOT/pages/provisioning-aliyun.adoc
@@ -24,7 +24,7 @@ STREAM="stable"
 coreos-installer download --decompress -s "${STREAM}" -p aliyun -f qcow2.xz
 ----
 
-Alternatively, you can manually download an Alibaba Cloud image from the https://getfedora.org/coreos/download?tab=cloud_operators[download page]. Verify the download, following the instructions on that page, and decompress it.
+Alternatively, you can manually download an Alibaba Cloud image from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page]. Verify the download, following the instructions on that page, and decompress it.
 
 == Uploading the image to Alibaba Cloud
 

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -25,7 +25,7 @@ stream="stable"
 coreos-installer download --decompress -s "${stream}" -p azure -f vhd.xz
 ----
 
-Alternatively, you can manually download an Azure image from the https://getfedora.org/coreos/download?tab=cloud_operators[download page]. Verify the download, following the instructions on that page, and decompress it.
+Alternatively, you can manually download an Azure image from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page]. Verify the download, following the instructions on that page, and decompress it.
 
 == Uploading the image to Azure
 

--- a/modules/ROOT/pages/provisioning-digitalocean.adoc
+++ b/modules/ROOT/pages/provisioning-digitalocean.adoc
@@ -16,7 +16,7 @@ You also need to have access to a DigitalOcean account. The examples below use t
 
 Fedora CoreOS is designed to be updated automatically, with different schedules per stream.
 
-. Once you have picked the relevant stream, find the corresponding DigitalOcean image on the https://getfedora.org/coreos/download?tab=cloud_operators[download page] and copy the URL of the Download link.
+. Once you have picked the relevant stream, find the corresponding DigitalOcean image on the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page] and copy the URL of the Download link.
 
 . Create the custom image:
 +

--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -25,7 +25,7 @@ STREAM="stable"
 coreos-installer download -d -s "${STREAM}" -p exoscale -f qcow2.xz
 ----
 
-Alternatively, QCOW2 images can be downloaded from the https://getfedora.org/coreos/download?tab=cloud_operators[download page] and manually decompressed.
+Alternatively, QCOW2 images can be downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page] and manually decompressed.
 
 Next you can https://community.exoscale.com/documentation/compute/custom-templates/#register-a-custom-template[Register a Custom Template]. This can be done from the https://portal.exoscale.com/compute/templates/add[Web Portal] or the https://community.exoscale.com/documentation/tools/exoscale-command-line-interface/[Exoscale CLI]. Either option requires the uncompressed image to be uploaded somewhere public and for the URL and an MD5 checksum to be provided during registration. One option is to use the object storage provided by Exoscale to host the image.
 

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -42,7 +42,7 @@ There are also several other pieces that need to be in place, like a VPC, SSH ke
 The following sets of commands will show you how to download the most recent image for a stream, upload it to cloud storage, and then create the cloud image in IBM Cloud. It is worth noting that Fedora CoreOS comes in three streams, with different update schedules per stream. These steps show the `stable` stream as an example, but can be used for other streams too.
 
 
-.Fetch the latest image suitable for your target stream (or https://getfedora.org/coreos/download/[download and verify] it from the web).
+.Fetch the latest image suitable for your target stream (or https://fedoraproject.org/coreos/download/[download and verify] it from the web).
 [source, bash]
 ----
 STREAM='stable'

--- a/modules/ROOT/pages/provisioning-openstack.adoc
+++ b/modules/ROOT/pages/provisioning-openstack.adoc
@@ -35,7 +35,7 @@ coreos-installer download --decompress -s $STREAM -p openstack -f qcow2.xz
 ----
 
 Alternatively, you can manually download an OpenStack image from the
-https://getfedora.org/coreos/download?tab=cloud_operators[download page].
+https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page].
 Verify the download, following the instructions on that page, and decompress it.
 
 == Uploading the Image to OpenStack

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -20,7 +20,7 @@ You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM
 
 === Fetching the QCOW2 image
 
-Fetch the latest image suitable for your target stream (or https://getfedora.org/coreos/download/[download and verify] it from the web).
+Fetch the latest image suitable for your target stream (or https://fedoraproject.org/coreos/download/[download and verify] it from the web).
 
 [source, bash]
 ----

--- a/modules/ROOT/pages/provisioning-virtualbox.adoc
+++ b/modules/ROOT/pages/provisioning-virtualbox.adoc
@@ -19,7 +19,7 @@ STREAM="stable"
 coreos-installer download -s "${STREAM}" -p virtualbox -f ova
 ----
 
-Alternatively, OVA images can be manually downloaded from the https://getfedora.org/coreos/download?tab=metal_virtualized[download page].
+Alternatively, OVA images can be manually downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[download page].
 
 == Booting a new VM on VirtualBox
 

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -25,7 +25,7 @@ STREAM="stable"
 coreos-installer download -s "${STREAM}" -p vmware -f ova
 ----
 
-Alternatively, OVA images can be manually downloaded from the https://getfedora.org/coreos/download?tab=metal_virtualized[download page].
+Alternatively, OVA images can be manually downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[download page].
 
 === Encoding Ignition configuration
 

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -24,7 +24,7 @@ See https://www.vultr.com/docs/vultr-object-storage[Vultr documentation] for fur
 
 Fedora CoreOS comes in three streams, with different update schedules per stream. These steps show the `stable` stream as an example, but can be used for other streams too.
 
-. Fetch the latest image suitable for your target stream (or https://getfedora.org/coreos/download/[download and verify] it from the web).
+. Fetch the latest image suitable for your target stream (or https://fedoraproject.org/coreos/download/[download and verify] it from the web).
 +
 [source, bash]
 ----

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -113,7 +113,7 @@ You are now ready to proceed with the xref:tutorial-autologin.adoc[first tutoria
 
 === Manual download
 
-If none of the previous solutions work for you, you can still manually download Fedora CoreOS from https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[getfedora.org] with:
+If none of the previous solutions work for you, you can still manually download Fedora CoreOS from https://fedoraproject.org/coreos/download/?stream=stable#baremetal[fedoraproject.org] with:
 
 [source,bash,subs="attributes"]
 ----

--- a/modules/ROOT/pages/update-barrier-signing-keys.adoc
+++ b/modules/ROOT/pages/update-barrier-signing-keys.adoc
@@ -1,6 +1,6 @@
 = Signing keys and updates
 
-All binary artifacts, ostree commits, and OS images belonging to Fedora and Fedora CoreOS (FCOS) are signed via GPG. The current set of trusted signing keys is available at https://getfedora.org/security/.
+All binary artifacts, ostree commits, and OS images belonging to Fedora and Fedora CoreOS (FCOS) are signed via GPG. The current set of trusted signing keys is available at https://fedoraproject.org/security/.
 
 == Keys rotation and update barriers
 


### PR DESCRIPTION
This tries to get rid of all mentions of getfedora.org. It also fixes the forum link to be https://discussion.fedoraproject.org/tag/coreos