### PR TITLE
lint: fix shellcheck findings in embedded shell scripts

### DIFF
--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -6,10 +6,10 @@
 ----
 STREAM="stable"
 # as an installed binary:
-coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
+coreos-installer download -s $STREAM -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
 # or as a container:
-podman run --pull=always --rm -v $HOME/.local/share/libvirt/images/:/data -w /data \
-    quay.io/coreos/coreos-installer:release download -s "${STREAM}" -p qemu -f qcow2.xz --decompress
+podman run --pull=always --rm -v "${HOME}/.local/share/libvirt/images/:/data" -w /data \
+    quay.io/coreos/coreos-installer:release download -s $STREAM -p qemu -f qcow2.xz --decompress
 ----
 +
 

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -49,7 +49,7 @@ podman run --interactive --rm quay.io/coreos/butane:release \
 [source,bash]
 ----
 podman run --interactive --rm --security-opt label=disable \
-       --volume ${PWD}:/pwd --workdir /pwd quay.io/coreos/butane:release \
+       --volume "${PWD}:/pwd" --workdir /pwd quay.io/coreos/butane:release \
        --pretty --strict your_config.bu > transpiled_config.ign
 ----
 
@@ -57,9 +57,9 @@ To make it simpler to type, you may also add the following alias to your shell c
 
 [source,bash]
 ----
-alias butane='podman run --rm --interactive       \
-              --security-opt label=disable        \
-              --volume ${PWD}:/pwd --workdir /pwd \
+alias butane='podman run --rm --interactive         \
+              --security-opt label=disable          \
+              --volume "${PWD}:/pwd" --workdir /pwd \
               quay.io/coreos/butane:release'
 ----
 

--- a/modules/ROOT/pages/provisioning-aliyun.adoc
+++ b/modules/ROOT/pages/provisioning-aliyun.adoc
@@ -21,7 +21,7 @@ Once you have picked the relevant stream, download, verify, and decompress the l
 [source, bash]
 ----
 STREAM="stable"
-coreos-installer download --decompress -s "${STREAM}" -p aliyun -f qcow2.xz
+coreos-installer download --decompress -s $STREAM -p aliyun -f qcow2.xz
 ----
 
 Alternatively, you can manually download an Alibaba Cloud image from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page]. Verify the download, following the instructions on that page, and decompress it.
@@ -140,7 +140,7 @@ VSWITCH_ID=$(aliyun vpc CreateVSwitch \
 ----
 KEY_PAIR_NAME="fcos-key"
 PUBLIC_KEY_PATH="<Please fill the path to your public key>"
-PUBLIC_KEY_BODY=$(cat ${PUBLIC_KEY_PATH})
+PUBLIC_KEY_BODY=$(cat "${PUBLIC_KEY_PATH}")
 aliyun ecs ImportKeyPair --region="${REGION}" \
     --KeyPairName="${KEY_PAIR_NAME}" --PublicKeyBody="${PUBLIC_KEY_BODY}"
 ----

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -21,8 +21,8 @@ Once you have picked the relevant stream, download, verify, and decompress the l
 
 [source, bash]
 ----
-stream="stable"
-coreos-installer download --decompress -s "${stream}" -p azure -f vhd.xz
+STREAM="stable"
+coreos-installer download --decompress -s $STREAM -p azure -f vhd.xz
 ----
 
 Alternatively, you can manually download an Azure image from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page]. Verify the download, following the instructions on that page, and decompress it.

--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -22,7 +22,7 @@ Exoscale provides https://community.exoscale.com/documentation/compute/custom-te
 [source, bash]
 ----
 STREAM="stable"
-coreos-installer download -d -s "${STREAM}" -p exoscale -f qcow2.xz
+coreos-installer download -d -s $STREAM -p exoscale -f qcow2.xz
 ----
 
 Alternatively, QCOW2 images can be downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#cloud_images[download page] and manually decompressed.
@@ -35,15 +35,15 @@ Next you can https://community.exoscale.com/documentation/compute/custom-templat
 # Set the version and calcuate the checksum
 FCOS_VERSION='...'
 FILE="fedora-coreos-${FCOS_VERSION}-exoscale.x86_64.qcow2"
-CHECKSUM=$(md5sum $FILE | cut -d " " -f 1)
+CHECKSUM=$(md5sum "${FILE}" | cut -d " " -f 1)
 
 # Upload to object storage
 BUCKET='newbucket'
 exo storage mb "sos://${BUCKET}"
-exo storage upload --acl public-read $FILE "sos://${BUCKET}/image-import/"
+exo storage upload --acl public-read "${FILE}" "sos://${BUCKET}/image-import/"
 
 # Create the template using given URL and CHECKSUM
-URL=$(exo storage show "sos://${BUCKET}/image-import/$FILE" --output-template "{{.URL}}")
+URL=$(exo storage show "sos://${BUCKET}/image-import/${FILE}" --output-template "{{.URL}}")
 TEMPLATE="fedora-coreos-${FCOS_VERSION}"
 exo compute instance-template register --boot-mode=uefi $TEMPLATE $URL $CHECKSUM
 ----
@@ -72,9 +72,9 @@ TYPE='standard.medium'
 DISK='10' # in GiB
 SSHKEY='key-name'
 TEMPLATE=$TEMPLATE # template name set above
-exo compute instance create $NAME \
+exo compute instance create "${NAME}" \
     --disk-size $DISK \
-    --ssh-key $SSHKEY \
+    --ssh-key "${SSHKEY}" \
     --template $TEMPLATE \
     --template-visibility private \
     --cloud-init "path/to/ignition-file.ign"
@@ -82,7 +82,7 @@ exo compute instance create $NAME \
 
 NOTE: If just SSH access is desired and no further customization is required, you don't need to pass any Ignition file and can omit the `--cloud-init` argument.
 
-TIP: You can find out the instance's assigned IP by running `exo compute instance show $NAME`
+TIP: You can find out the instance's assigned IP by running `exo compute instance show "${NAME}"`
 
 You now should be able to SSH into the instance using the associated IP address.
 

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -66,7 +66,7 @@ ibmcloud iam authorization-policy-create is --source-resource-type image cloud-o
 FCOS_VERSION='...'
 FILE="fedora-coreos-${FCOS_VERSION}-ibmcloud.${ARCH}.qcow2"
 ibmcloud cos create-bucket --bucket $BUCKET --ibm-service-instance-id $SERVICE_INSTANCE_ID
-ibmcloud cos upload --bucket=$BUCKET --key=$FILE --file=$FILE
+ibmcloud cos upload --bucket=$BUCKET --key="${FILE}" --file="${FILE}"
 ----
 
 .Create the image from the storage object.
@@ -76,7 +76,7 @@ IMAGE=${FILE:0:-6}     # pull off .qcow2
 IMAGE=${IMAGE//[._]/-} # replace . and _ with -
 [ $ARCH == 'x86_64' ] && OSNAME='fedora-coreos-stable-amd64'
 [ $ARCH == 's390x' ] && OSNAME='red-8-s390x-byol'
-ibmcloud is image-create $IMAGE --file "cos://${REGION}/${BUCKET}/${FILE}" --os-name $OSNAME
+ibmcloud is image-create "${IMAGE}" --file "cos://${REGION}/${BUCKET}/${FILE}" --os-name $OSNAME
 ----
 
 NOTE: For `s390x` we use `--os-name=red-8-s390x-byol` (a RHEL 8 profile) here because there is not currently a `fedora-coreos-stable-s390x` profile to use.
@@ -105,10 +105,10 @@ VPC='r014-c9c65cc4-cfd3-44de-ad54-865aac182ea1'    # `ibmcloud is vpcs`
 IMAGE='r014-1823b4cf-9c63-499e-8a27-b771be714ad8'  # `ibmcloud is images --visibility private`
 SUBNET='0777-bf99cbf4-bc82-4c46-895a-5b7304201182' # `ibmcloud is subnets`
 SSHKEY='r014-b44c37d0-5c21-4c2b-aba2-438a5b0a228d' # `ibmcloud is keys`
-ibmcloud is instance-create $NAME $VPC $ZONE $PROFILE $SUBNET --image $IMAGE --keys $SSHKEY --user-data @example.ign
+ibmcloud is instance-create "${NAME}" $VPC $ZONE $PROFILE $SUBNET --image $IMAGE --keys $SSHKEY --user-data @example.ign
 ----
 
-TIP: If needed you may have to first create a subnet with a command like `'ibmcloud is subnet-create my-subnet $VPC --ipv4-address-count 256 --zone $ZONE'`.
+TIP: If needed you may have to first create a subnet with a command like `ibmcloud is subnet-create my-subnet $VPC --ipv4-address-count 256 --zone $ZONE`.
 
 WARNING: Make sure you choose an appropriate instance type based on your architecture. For example, you may want to use `bz2-2x8` instead of `bx2-2x8` above if you are targeting `s390x`.
 

--- a/modules/ROOT/pages/provisioning-openstack.adoc
+++ b/modules/ROOT/pages/provisioning-openstack.adoc
@@ -30,7 +30,7 @@ NOTE: For more information on FCOS stream offerings see xref:update-streams.adoc
 
 [source, bash]
 ----
-STREAM='stable'
+STREAM="stable"
 coreos-installer download --decompress -s $STREAM -p openstack -f qcow2.xz
 ----
 
@@ -45,7 +45,7 @@ Verify the download, following the instructions on that page, and decompress it.
 ----
 FILE=fedora-coreos-XX.XXXXXXXX.X.X-openstack.x86_64.qcow2
 IMAGE=${FILE:0:-6} # pull off .qcow2
-openstack image create --disk-format=qcow2 --min-disk=10 --min-ram=2 --progress --file=$FILE $IMAGE
+openstack image create --disk-format=qcow2 --min-disk=10 --min-ram=2 --progress --file="${FILE}" "${IMAGE}"
 ----
 
 NOTE: If you're uploading an `aarch64` disk image then add `--property architecture=aarch64`.
@@ -53,7 +53,7 @@ NOTE: If you're uploading an `aarch64` disk image then add `--property architect
 .Monitor image creation progress by listing the image
 [source, bash]
 ----
-openstack image list --name=$IMAGE
+openstack image list --name="${IMAGE}"
 ----
 
 Once the image is listed as `active`, it's ready to be used.
@@ -71,22 +71,22 @@ a file in the current directory named `example.ign`.
 .Launching a VM instance
 [source, bash]
 ----
-OPENSTACK_NETWORK=private
-OPENSTACK_KEYPAIR=mykeypair # optional
-OPENSTACK_FLAVOR=v1-standard-2
-INSTANCE_NAME=myinstance # choose a name
-openstack server create            \
-     --key-name=$OPENSTACK_KEYPAIR \
-     --network=$OPENSTACK_NETWORK  \
-     --flavor=$OPENSTACK_FLAVOR    \
-     --image=$IMAGE                \
-     --user-data ./example.ign     \
-     $INSTANCE_NAME
+OPENSTACK_NETWORK="private"
+OPENSTACK_KEYPAIR="mykeypair" # optional
+OPENSTACK_FLAVOR="v1-standard-2"
+INSTANCE_NAME="myinstance" # choose a name
+openstack server create                \
+     --key-name="${OPENSTACK_KEYPAIR}" \
+     --network=$OPENSTACK_NETWORK      \
+     --flavor=$OPENSTACK_FLAVOR        \
+     --image="${IMAGE}"                \
+     --user-data ./example.ign         \
+     "${INSTANCE_NAME}"
 ----
 
 NOTE: Specifying `--key-name` is optional if you provide an SSH key in your Ignition config.
 
-TIP: Monitor progress of the instance creation with `openstack server show $INSTANCE_NAME`.
+TIP: Monitor progress of the instance creation with `openstack server show "${INSTANCE_NAME}"`.
 You can also use the `--wait` parameter when calling `openstack server create` to block
 until the instance is active.
 
@@ -101,7 +101,7 @@ OPENSTACK_NETWORK=public
 openstack floating ip create $OPENSTACK_NETWORK
 
 FLOATING_IP=1.1.1.1  # from just created floating IP
-openstack server add floating ip $INSTANCE_NAME $FLOATING_IP
+openstack server add floating ip "${INSTANCE_NAME}" $FLOATING_IP
 ----
 
 You now should be able to SSH into the instance using the floating IP address.

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -25,7 +25,7 @@ Fetch the latest image suitable for your target stream (or https://fedoraproject
 [source, bash]
 ----
 STREAM="stable"
-coreos-installer download -s "${STREAM}" -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
+coreos-installer download -s $STREAM -p qemu -f qcow2.xz --decompress -C ~/.local/share/libvirt/images/
 ----
 
 === Setting up a new VM
@@ -47,14 +47,14 @@ IGNITION_DEVICE_ARG="-fw_cfg name=opt/com.coreos/config,file=${IGNITION_CONFIG}"
 IGNITION_DEVICE_ARG="-drive file=${IGNITION_CONFIG},if=none,format=raw,readonly=on,id=ignition -device virtio-blk,serial=ignition,drive=ignition"
 
 qemu-kvm -m 2048 -cpu host -nographic -snapshot \
-  -drive if=virtio,file=${IMAGE} ${IGNITION_DEVICE_ARG} \
+  -drive "if=virtio,file=${IMAGE}" ${IGNITION_DEVICE_ARG} \
   -nic user,model=virtio,hostfwd=tcp::2222-:22
 ----
 
 .Launching FCOS with QEMU (persistent storage)
 [source, bash]
 ----
-qemu-img create -f qcow2 -F qcow2 -b ${IMAGE} my-fcos-vm.qcow2
+qemu-img create -f qcow2 -F qcow2 -b "${IMAGE}" my-fcos-vm.qcow2
 qemu-kvm -m 2048 -cpu host -nographic \
   -drive if=virtio,file=my-fcos-vm.qcow2 ${IGNITION_DEVICE_ARG} \
   -nic user,model=virtio,hostfwd=tcp::2222-:22

--- a/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
+++ b/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
@@ -159,7 +159,7 @@ First, run `coreos-installer` to install to the target disk:
 [source, bash]
 ----
 FCOSDISK=/dev/sdX
-STREAM=stable # or `next` or `testing`
+STREAM="stable" # or `next` or `testing`
 sudo coreos-installer install -a aarch64 -s $STREAM -i config.ign $FCOSDISK
 ----
 

--- a/modules/ROOT/pages/provisioning-virtualbox.adoc
+++ b/modules/ROOT/pages/provisioning-virtualbox.adoc
@@ -16,7 +16,7 @@ Once you have picked the relevant stream, you can download the latest OVA:
 [source, bash]
 ----
 STREAM="stable"
-coreos-installer download -s "${STREAM}" -p virtualbox -f ova
+coreos-installer download -s $STREAM -p virtualbox -f ova
 ----
 
 Alternatively, OVA images can be manually downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[download page].

--- a/modules/ROOT/pages/provisioning-vmware.adoc
+++ b/modules/ROOT/pages/provisioning-vmware.adoc
@@ -22,7 +22,7 @@ Once you have picked the relevant stream, you can download the latest OVA:
 [source, bash]
 ----
 STREAM="stable"
-coreos-installer download -s "${STREAM}" -p vmware -f ova
+coreos-installer download -s $STREAM -p vmware -f ova
 ----
 
 Alternatively, OVA images can be manually downloaded from the https://fedoraproject.org/coreos/download/?stream=stable#baremetal[download page].
@@ -39,7 +39,7 @@ For maximum compatibility, it is recommended to use `base64` encoding and to pre
 [source, bash]
 ----
 CONFIG_ENCODING='base64'
-CONFIG_ENCODED=$(cat example.ign | base64 -w0 -)
+CONFIG_ENCODED=$(base64 -w0 example.ign)
 ----
 
 An alternative to plain `base64` encoding is `gzip+base64` as described in the https://coreos.github.io/ignition/supported-platforms/[Ignition supported platforms]. This is especially useful when submitting the Ignition config via `govc` as an _inline_ argument. In that case the encoded config is limited to slightly under 128 KiB on Linux, 256 KiB on macOS, and 32 KiB on Windows (8 KiB if using `cmd.exe` or PowerShell). If your config is larger than that limit, you may be able to submit it inline after compressing it with `gzip`.
@@ -47,7 +47,7 @@ An alternative to plain `base64` encoding is `gzip+base64` as described in the h
 [source, bash]
 ----
 CONFIG_ENCODING='gzip+base64'
-CONFIG_ENCODED=$(cat example.ign | gzip -9 | base64 -w0 -)
+CONFIG_ENCODED=$(gzip -9c example.ign | base64 -w0 -)
 ----
 
 If your generated Ignition configuration is still too large, you will encounter an `Argument list too long` error or similar. The solution to that problem depends on whether you are working with vSphere or Workstation/Fusion.
@@ -58,7 +58,7 @@ For vSphere, instead of inlining the configuration file within your shell, `govc
 ----
 CONFIG_ENCODING="gzip+base64"
 CONFIG_FILE="example.ign"
-CONFIG_FILE_ENCODED="${CONFIG_FILE}.gzip.b64"
+CONFIG_FILE_ENCODED="${CONFIG_FILE}.gz.b64"
 
 gzip -9c "${CONFIG_FILE}" | base64 -w0 - > "${CONFIG_FILE_ENCODED}"
 
@@ -72,7 +72,7 @@ In the case of Workstation/Fusion, or as a last resort in general, there is the 
 
 [source, bash]
 ----
-printf "extraConfig:guestinfo.ignition.config.data=$(cat example.ign | base64 -w0 -)\n" > ovftool.cfg
+echo "extraConfig:guestinfo.ignition.config.data=$(base64 -w0 example.ign)" > ovftool.cfg
 ----
 
 == Booting a new VM on Workstation or Fusion

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -29,7 +29,7 @@ Fedora CoreOS comes in three streams, with different update schedules per stream
 [source, bash]
 ----
 STREAM='stable'
-coreos-installer download -s "${STREAM}" -p vultr -f raw.xz --decompress
+coreos-installer download -s $STREAM -p vultr -f raw.xz --decompress
 ----
 
 . https://www.vultr.com/docs/how-to-use-s3cmd-with-vultr-object-storage[Use s3cmd to upload] the raw image to your bucket, and note its public URL.

--- a/modules/ROOT/pages/stream-metadata.adoc
+++ b/modules/ROOT/pages/stream-metadata.adoc
@@ -16,7 +16,7 @@ The `coreos-installer` tool has built-in support for fetching artifacts:
 
 [source, bash]
 ----
-STREAM='stable'
+STREAM="stable"
 coreos-installer download --decompress -s $STREAM -p openstack -f qcow2.xz
 ----
 
@@ -32,7 +32,7 @@ Fetch the latest `x86_64` AMI in `us-west-1` and use it to launch an instance:
 [source, bash]
 ----
 $ AMI=$(curl -sSL https://builds.coreos.fedoraproject.org/streams/stable.json | jq -r '.architectures.x86_64.images.aws.regions["us-west-1"].image')
-$ echo $AMI
+$ echo "${AMI}"
 ami-021238084bf8c95ff
 $ aws ec2 run-instances --region us-west-1 --image-id "${AMI}" ...
 ----

--- a/modules/ROOT/pages/tutorial-autologin.adoc
+++ b/modules/ROOT/pages/tutorial-autologin.adoc
@@ -122,7 +122,7 @@ chcon --verbose --type svirt_home_t autologin.ign
 virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable \
     --import --network=bridge=virbr0 --graphics=none \
     --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/autologin.ign" \
-    --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
+    --disk="size=20,backing_store=${PWD}/fedora-coreos.qcow2"
 ----
 
 The `virt-install` command will start an instance named `fcos` from the `fedora-coreos.qcow2` image using the `autologin.ign` Ignition config. It will auto-attach the serial console of the machine so you will be able to see the image bootup messages.

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -105,7 +105,7 @@ chcon --verbose --type svirt_home_t containers.ign
 virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable \
     --import --network=bridge=virbr0 --graphics=none \
     --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/containers.ign" \
-    --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
+    --disk="size=20,backing_store=${PWD}/fedora-coreos.qcow2"
 ----
 
 On the console you will see:

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -111,7 +111,7 @@ chcon --verbose --type svirt_home_t services.ign
 virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable \
     --import --network=bridge=virbr0 --graphics=none \
     --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/services.ign" \
-    --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
+    --disk="size=20,backing_store=${PWD}/fedora-coreos.qcow2"
 ----
 
 And view on the console that the `Detected Public IPv4` is shown in the console output right before you are dropped to a login prompt:

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -69,20 +69,20 @@ To make it simpler to type, you may add the following aliases to your shell conf
 
 [source,bash]
 ----
-alias butane='podman run --rm --interactive       \
-              --security-opt label=disable        \
-              --volume ${PWD}:/pwd --workdir /pwd \
+alias butane='podman run --rm --interactive         \
+              --security-opt label=disable          \
+              --volume "${PWD}:/pwd" --workdir /pwd \
               quay.io/coreos/butane:release'
 
-alias coreos-installer='podman run --pull=always            \
-                        --rm --interactive                  \
-                        --security-opt label=disable        \
-                        --volume ${PWD}:/pwd --workdir /pwd \
+alias coreos-installer='podman run --pull=always              \
+                        --rm --interactive                    \
+                        --security-opt label=disable          \
+                        --volume "${PWD}:/pwd" --workdir /pwd \
                         quay.io/coreos/coreos-installer:release'
 
-alias ignition-validate='podman run --rm --interactive       \
-                         --security-opt label=disable        \
-                         --volume ${PWD}:/pwd --workdir /pwd \
+alias ignition-validate='podman run --rm --interactive         \
+                         --security-opt label=disable          \
+                         --volume "${PWD}:/pwd" --workdir /pwd \
                          quay.io/coreos/ignition-validate:release'
 ----
 
@@ -131,8 +131,8 @@ If none of the previous solutions work for you, you can still manually download 
 [source,bash,subs="attributes"]
 ----
 RELEASE="{stable-version}"
-curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/$RELEASE/x86_64/fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz
-curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/$RELEASE/x86_64/fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz.sig
+curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/${RELEASE}/x86_64/fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz
+curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/${RELEASE}/x86_64/fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz.sig
 ----
 
 Once the archive has been downloaded, make sure to verify its integrity by following the instructions available by clicking on the `Verify signature & SHA256` button. You will have to download the checksum file, the signature and Fedora GPG keys to verify your download:
@@ -140,14 +140,14 @@ Once the archive has been downloaded, make sure to verify its integrity by follo
 [source,bash]
 ----
 curl https://fedoraproject.org/fedora.gpg | gpg --import
-gpg --verify fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz.sig
+gpg --verify fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz.sig
 ----
 
 Once you have verified the archive, you can extract it with:
 
 [source,bash]
 ----
-unxz fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz
+unxz fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz
 ----
 
 To make the tutorial simpler, you should rename the image that we have just downloaded to a shorter name:

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -11,8 +11,8 @@ One of the defining features of Fedora CoreOS is automatic updates. To see them 
 [source,bash]
 ----
 RELEASE=$(curl https://builds.coreos.fedoraproject.org/prod/streams/stable/releases.json | jq -r '.releases[-2].version')
-curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/$RELEASE/x86_64/fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz
-curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/$RELEASE/x86_64/fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz.sig
+curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/${RELEASE}/x86_64/fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz
+curl -O https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/${RELEASE}/x86_64/fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz.sig
 ----
 
 Once the archive has been downloaded, make sure to verify its integrity:
@@ -20,7 +20,7 @@ Once the archive has been downloaded, make sure to verify its integrity:
 [source,bash]
 ----
 curl https://fedoraproject.org/fedora.gpg | gpg --import
-gpg --verify fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz.sig
+gpg --verify fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz.sig
 ----
 
 TIP: Look for *"Good signature from"* in the output.
@@ -29,14 +29,14 @@ Once you have verified the archive, you can extract it with:
 
 [source,bash]
 ----
-unxz fedora-coreos-$RELEASE-qemu.x86_64.qcow2.xz
+unxz fedora-coreos-${RELEASE}-qemu.x86_64.qcow2.xz
 ----
 
 To make the tutorial simpler, you should rename this image to a shorter name:
 
 [source,bash]
 ----
-mv fedora-coreos-$RELEASE-qemu.x86_64.qcow2 fedora-coreos-older.qcow2
+mv fedora-coreos-${RELEASE}-qemu.x86_64.qcow2 fedora-coreos-older.qcow2
 ----
 
 == Writing the Butane config and converting to Ignition
@@ -101,7 +101,7 @@ chcon --verbose --type svirt_home_t updates.ign
 virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable \
     --import --network=bridge=virbr0 --graphics=none \
     --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/updates.ign" \
-    --disk=size=20,backing_store=${PWD}/fedora-coreos-older.qcow2
+    --disk="size=20,backing_store=${PWD}/fedora-coreos-older.qcow2"
 ----
 
 Disconnect from the serial console by pressing `CTRL` + `]` and then use the reported IP address for the NIC from the serial console to log in using the `core` user via SSH:

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -197,7 +197,7 @@ chcon --verbose --type svirt_home_t user.ign
 virt-install --name=fcos --vcpus=2 --ram=2048 --os-variant=fedora-coreos-stable \
     --import --network=bridge=virbr0 --graphics=none \
     --qemu-commandline="-fw_cfg name=opt/com.coreos/config,file=${PWD}/user.ign" \
-    --disk=size=20,backing_store=${PWD}/fedora-coreos.qcow2
+    --disk="size=20,backing_store=${PWD}/fedora-coreos.qcow2"
 ----
 
 We can then verify that the unit has been started under the sleeper systemd user instance:


### PR DESCRIPTION
- prevent wordsplitting and accidental globbling by quoting variables
- use parameter expansion with braces for consistency
- remove a number of useless cat-expressions
- use printf with format string syntax

vmware:
- use correct gzip file ending (See https://github.com/coreos/fedora-coreos-docs/pull/524#discussion_r1159476263 for details) in example