### PR TITLE
docs (toolbox) : Corrected Toolbx | Toolbox spelling error?

### DIFF
--- a/modules/ROOT/pages/debugging-with-toolbox.adoc
+++ b/modules/ROOT/pages/debugging-with-toolbox.adoc
@@ -1,4 +1,4 @@
-= Debugging with Toolbx
+= Debugging with Toolbox
 
 The FCOS image is kept minimal by design to reduce the image size and the
 attack surface. This means that it does not include every troubleshooting tools
@@ -6,9 +6,9 @@ that a normal OS may include. Instead, the recommended approach is to leverage
 containers with the https://containertoolbx.org/[toolbox] utility
 included in the image.
 
-== What is Toolbx?
+== What is Toolbox?
 
-Toolbx is a utility that allows you to create privileged containers meant to
+Toolbox is a utility that allows you to create privileged containers meant to
 debug and troubleshoot your instance. It is a wrapper around podman which
 starts long running containers with default mounts and namespaces to facilitate
 debugging the host system.
@@ -16,7 +16,7 @@ debugging the host system.
 These containers can then be used to install tools that you may need for
 troubleshooting.
 
-== Using Toolbx
+== Using Toolbox
 
 You can create a new toolbox by running the command below. On the first run,
 this will ask you if you want to use the image
@@ -63,6 +63,6 @@ from the host with the following command.
 toolbox rm --force fedora-toolbox-35
 ----
 
-NOTE: Toolbx allows you to create toolboxes with your custom
+NOTE: Toolbox allows you to create toolboxes with your custom
 images. You can find more details in the
 https://github.com/containers/toolbox/tree/main/doc[toolbox manpages].


### PR DESCRIPTION
I'm not 100% sure if this choice of spelling was unintentional, but I saw it and thought it might need fixing :)