### PR TITLE
Drop mentions of CL/AH except migration guides; clean up FAQ

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -18,11 +18,11 @@ with rpm-ostree and SELinux hardening from Project Atomic. Its goal is
 to provide the best container host to run containerized workloads
 securely and at scale.
 
-== How does Fedora CoreOS relate to Red Hat CoreOS?
+== How does Fedora CoreOS relate to RHEL CoreOS?
 
 Fedora CoreOS is a freely available, community distribution that is the
-upstream basis for Red Hat CoreOS. While Fedora CoreOS embraces a
-variety of containerized use cases, Red Hat CoreOS provides a
+upstream basis for RHEL CoreOS. While Fedora CoreOS embraces a
+variety of containerized use cases, RHEL CoreOS provides a
 focused OS for OpenShift, released and life-cycled in tandem
 with the platform.
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -26,39 +26,6 @@ variety of containerized use cases, RHEL CoreOS provides a
 focused OS for OpenShift, released and life-cycled in tandem
 with the platform.
 
-== Does Fedora CoreOS replace Container Linux? What happens to CL?
-
-Fedora CoreOS is the official successor to CoreOS Container Linux, but it
-is not a drop-in replacement. CoreOS Container Linux will reach its
-https://coreos.com/os/eol/[end of life] on May 26, 2020, and will no longer
-receive updates after that date. For notes on migrating from Container Linux
-to Fedora CoreOS, see the xref:migrate-cl.adoc[migration guide].
-
-== Does Fedora CoreOS replace Fedora Atomic Host? What happens to Fedora Atomic Host and CentOS Atomic Host?
-
-Fedora CoreOS is the official successor to Fedora Atomic Host. The
-last Fedora Atomic Host release was version 29, which has now reached
-end-of-life.
-
-CentOS Atomic Host will continue producing downstream rebuilds of RHEL
-Atomic Host and will align with the end-of-life. The Fedora CoreOS
-project will be the consolidation point for the community distributions.
-Users are encouraged to move there in the future.
-
-== What happens to Project Atomic?
-
-Project Atomic is an umbrella project consisting of two flavors of
-Atomic Host (Fedora and CentOS) as well as various other
-container-related projects. Project Atomic as a project name will be
-sunset by the end of 2018 with a stronger individual focus on its
-successful projects such as Buildah and Cockpit. This merges the
-community side of the operating system more effectively with Fedora and
-allows for a clearer communication for other community-supported
-projects, specifically the well-adopted
-https://twitter.com/hashtag/nobigfatdaemons?src=hash[#nobigfatdaemons]
-approach of https://github.com/projectatomic/buildah[Buildah] and the
-versatile GUI server manager https://cockpit-project.org/[Cockpit].
-
 == What are the communication channels around Fedora CoreOS?
 
 We have the following new communication channels around Fedora CoreOS:
@@ -107,23 +74,6 @@ made changes. The content under `/var` is left untouched by rpm-ostree when
 applying upgrades or rollbacks. For more information, refer to the
 https://docs.fedoraproject.org/en-US/fedora-coreos/storage/#_mounted_filesystems[Mounted Filesystems]
 section.
-
-== How do I migrate from Container Linux to Fedora CoreOS?
-
-Migrations can be accomplished by re-provisioning the machine with
-Fedora CoreOS. For notes on migrating from Container Linux
-to Fedora CoreOS, see the xref:migrate-cl.adoc[migration guide].
-
-== How do I migrate from Fedora Atomic Host to Fedora CoreOS?
-
-As with Container Linux, the best practice is to re-provision the node, due
-to the cloud-init/Ignition transition at least. Since Fedora CoreOS uses
-rpm-ostree technology, it may be possible to rebase from Fedora
-Atomic Host to Fedora CoreOS, but it is not recommended. It's
-preferable to gain experience deploying systems using Ignition so
-that they can be re-provisioned easily if needed. For notes on migrating
-from Atomic Host to Fedora CoreOS, see the
-xref:migrate-ah.adoc[migration guide].
 
 == Which container runtimes are available on Fedora CoreOS?
 
@@ -288,47 +238,6 @@ systemd:
 
 For more information see
 https://github.com/coreos/fedora-coreos-tracker/issues/519[the tracker issue discussion].
-
-== Why does SSH stop working after upgrading to Fedora 33?
-
-In Fedora 33 there was a change to
-https://www.fedoraproject.org/wiki/Changes/StrongCryptoSettings2[implement stronger crypto defaults].
-Part of this included taking the
-https://www.openssh.com/txt/release-8.3[advice of OpenSSH] upstream
-and disabling the use of the `ssh-rsa` public key signature algorithm.
-
-You may hit issues if you use RSA keys and:
-
-* use an old version of the `SSH` client
-* use tooling/software libraries that don't support using RSA SHA2 public key signatures
-
-For example, Go has an https://github.com/golang/go/issues/37278[open issue]
-to solve this problem in its SSH implementation, but has yet to resolve it.
-This has been hit and worked around by the FCOS community in
-our build tooling and also our higher level projects:
-
-- https://github.com/coreos/fedora-coreos-tracker/issues/699[coreos/fedora-coreos-tracker#699]
-- https://github.com/coreos/coreos-assembler/issues/1772[coreos/coreos-assembler#1772]
-
-If you run into this problem and need to work around the issue, you
-have a few options:
-
-- Switch to a newer non-RSA key type.
-- Provide a configuration to your machine that re-enables the insecure key signatures:
-
-.Example Butane config for re-enabling SSH RSA SHA1 key signatures
-[source, yaml]
-----
-variant: fcos
-version: 1.4.0
-storage:
-  files:
-    - path: /etc/ssh/sshd_config.d/10-insecure-rsa-keysig.conf
-      mode: 0600
-      contents:
-        inline: |
-          PubkeyAcceptedKeyTypes=+ssh-rsa
-----
 
 == Why do I get SELinux denials after updates if I have local policy modifications?
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -18,8 +18,6 @@ with rpm-ostree and SELinux hardening from Project Atomic. Its goal is
 to provide the best container host to run containerized workloads
 securely and at scale.
 
-https://discussion.fedoraproject.org/t/launch-faq-what-is-fedora-coreos/40[Discuss on discussion.fedoraproject.org]
-
 == How does Fedora CoreOS relate to Red Hat CoreOS?
 
 Fedora CoreOS is a freely available, community distribution that is the
@@ -28,8 +26,6 @@ variety of containerized use cases, Red Hat CoreOS provides a
 focused OS for OpenShift, released and life-cycled in tandem
 with the platform.
 
-https://discussion.fedoraproject.org/t/launch-faq-how-does-fedora-coreos-relate-to-red-hat-coreos/41[Discuss on discussion.fedoraproject.org]
-
 == Does Fedora CoreOS replace Container Linux? What happens to CL?
 
 Fedora CoreOS is the official successor to CoreOS Container Linux, but it
@@ -37,8 +33,6 @@ is not a drop-in replacement. CoreOS Container Linux will reach its
 https://coreos.com/os/eol/[end of life] on May 26, 2020, and will no longer
 receive updates after that date. For notes on migrating from Container Linux
 to Fedora CoreOS, see the xref:migrate-cl.adoc[migration guide].
-
-https://discussion.fedoraproject.org/t/launch-faq-does-fedora-coreos-replace-container-linux-what-happens-to-cl/42[Discuss on discussion.fedoraproject.org]
 
 == Does Fedora CoreOS replace Fedora Atomic Host? What happens to Fedora Atomic Host and CentOS Atomic Host?
 
@@ -50,8 +44,6 @@ CentOS Atomic Host will continue producing downstream rebuilds of RHEL
 Atomic Host and will align with the end-of-life. The Fedora CoreOS
 project will be the consolidation point for the community distributions.
 Users are encouraged to move there in the future.
-
-https://discussion.fedoraproject.org/t/launch-faq-does-fedora-coreos-replace-fedora-atomic-host-what-happens-to-fedora-atomic-host-and-centos-atomic-host/43[Discuss on discussion.fedoraproject.org]
 
 == What happens to Project Atomic?
 
@@ -66,8 +58,6 @@ projects, specifically the well-adopted
 https://twitter.com/hashtag/nobigfatdaemons?src=hash[#nobigfatdaemons]
 approach of https://github.com/projectatomic/buildah[Buildah] and the
 versatile GUI server manager https://cockpit-project.org/[Cockpit].
-
-https://discussion.fedoraproject.org/t/launch-faq-what-happens-to-project-atomic/44/1[Discuss on discussion.fedoraproject.org]
 
 == What are the communication channels around Fedora CoreOS?
 
@@ -84,15 +74,11 @@ There is a community meeting that happens every week. See the https://calendar.f
 
 If you think you have found a problem with Fedora CoreOS, file an issue in our https://github.com/coreos/fedora-coreos-tracker/issues[issue tracker].
 
-https://discussion.fedoraproject.org/t/launch-faq-what-are-the-communication-channels-around-fedora-coreos/46/1[Discuss on discussion.fedoraproject.org]
-
 == Technical FAQ
 
 === Where can I download Fedora CoreOS?
 
 Fedora CoreOS artifacts are available at https://fedoraproject.org/en/coreos/download/[fedoraproject.org].
-
-https://discussion.fedoraproject.org/t/launch-faq-where-can-i-download-fedora-coreos/47/1[Discuss on discussion.fedoraproject.org]
 
 == Does Fedora CoreOS embrace the Container Linux Update Philosophy?
 
@@ -103,8 +89,6 @@ service based on rpm-ostree technologies, with a server component that
 can be optionally self-hosted. Failures that prevent an update from
 booting will automatically be reverted.
 
-https://discussion.fedoraproject.org/t/launch-faq-does-fedora-coreos-embrace-the-container-linux-update-philosophy/48/1[Discuss on discussion.fedoraproject.org]
-
 == How are Fedora CoreOS nodes provisioned? Can I re-use existing cloud-init configurations?
 
 Fedora CoreOS is provisioned with Ignition. However, existing
@@ -112,8 +96,6 @@ Ignition configurations will require changes, as the OS configuration
 will be different from Container Linux. Existing cloud-init
 configurations are not supported and will need to be migrated into their
 Ignition equivalent.
-
-https://discussion.fedoraproject.org/t/launch-faq-how-are-fedora-coreos-nodes-provisioned-can-i-re-use-existing-cloud-init-configurations/49/1[Discuss on discussion.fedoraproject.org]
 
 == What data persists across upgrades and reboots?
 
@@ -132,8 +114,6 @@ Migrations can be accomplished by re-provisioning the machine with
 Fedora CoreOS. For notes on migrating from Container Linux
 to Fedora CoreOS, see the xref:migrate-cl.adoc[migration guide].
 
-https://discussion.fedoraproject.org/t/launch-faq-how-do-i-migrate-from-container-linux-to-fedora-coreos/50/1[Discuss on discussion.fedoraproject.org]
-
 == How do I migrate from Fedora Atomic Host to Fedora CoreOS?
 
 As with Container Linux, the best practice is to re-provision the node, due
@@ -145,15 +125,11 @@ that they can be re-provisioned easily if needed. For notes on migrating
 from Atomic Host to Fedora CoreOS, see the
 xref:migrate-ah.adoc[migration guide].
 
-https://discussion.fedoraproject.org/t/launch-faq-how-do-i-migrate-from-fedora-atomic-host-to-fedora-coreos/51/1[Discuss on discussion.fedoraproject.org]
-
 == Which container runtimes are available on Fedora CoreOS?
 
 Fedora CoreOS includes Docker and podman by default.
 Based on community engagement and support this list could
 change over time.
-
-https://discussion.fedoraproject.org/t/launch-faq-which-container-runtimes-are-available-on-fedora-coreos/52/1[Discuss on discussion.fedoraproject.org]
 
 == Can I run Kubernetes on Fedora CoreOS?
 
@@ -163,8 +139,6 @@ Container Linux and Atomic Host. We will work with the upstream
 Kubernetes community on tools (e.g. kubeadm) and best practices for
 installing Kubernetes on Fedora CoreOS.
 
-https://discussion.fedoraproject.org/t/launch-faq-can-i-run-kubernetes-on-fedora-coreos/54/1[Discuss on discussion.fedoraproject.org]
-
 == How do I run custom applications on Fedora CoreOS?
 
 On Fedora CoreOS, containers are the way to install and configure any
@@ -172,8 +146,6 @@ software not provided by the base operating system. The package layering
 mechanism provided by rpm-ostree will continue to exist for use in
 debugging a Fedora CoreOS machine, but we strongly discourage its use.
 For more about this, please refer to xref:running-containers.adoc[documentation].
-
-https://discussion.fedoraproject.org/t/launch-faq-how-do-i-run-custom-applications-on-fedora-coreos/55/1[Discuss on discussion.fedoraproject.org]
 
 == Where is my preferred tool for troubleshooting?
 
@@ -193,8 +165,6 @@ The capabilities of https://github.com/coreos/container-linux-update-operator[Co
 have been embedded into the https://github.com/openshift/machine-config-operator[Machine Config Operator (MCO)],
 which is a core component of OKD.
 The MCO additionally covers reconciliation of machine configuration changes.
-
-https://discussion.fedoraproject.org/t/launch-faq-how-do-i-coordinate-cluster-wide-os-updates-is-locksmith-or-the-container-linux-update-operator-available-for-fedora-coreos/56[Discuss on discussion.fedoraproject.org]
 
 == How do I upload Fedora CoreOS to private AWS EC2 regions?
 
@@ -247,8 +217,6 @@ systemd:
 == Are Fedora CoreOS x86_64 disk images hybrid BIOS+UEFI bootable?
 
 The x86_64 images we provide can be used for either BIOS (legacy) boot or UEFI boot. They contain a hybrid BIOS/UEFI partition setup that allows them to be used for either. The exception to that is the `metal4k` 4k native image, which is targeted at disks with 4k sectors and https://github.com/coreos/coreos-assembler/blob/12029fea7798fa5d3535eafcf8c3d02f9a6095e4/src/cmd-buildextend-metal#L200-L202[does not have a BIOS boot partition] because 4k native disks are https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/hard-drives-and-partitions#advanced-format-drives[only supported with UEFI].
-
-https://discussion.fedoraproject.org/t/are-fedora-coreos-disk-images-hybrid-bios-uefi-bootable/21911[Discuss on discussion.fedoraproject.org]
 
 == What's the difference between Ignition and Butane configurations?
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -51,10 +51,9 @@ Fedora CoreOS artifacts are available at https://fedoraproject.org/en/coreos/dow
 
 Yes, Fedora CoreOS comes with automatic
 updates and regular releases. Multiple update channels are provided
-catering to different users' needs. It introduces a new node-update
+catering to different users' needs. Fedora CoreOS provides a node-update
 service based on rpm-ostree technologies, with a server component that
-can be optionally self-hosted. Failures that prevent an update from
-booting will automatically be reverted.
+can be optionally self-hosted.
 
 == How are Fedora CoreOS nodes provisioned? Can I re-use existing cloud-init configurations?
 
@@ -83,11 +82,8 @@ change over time.
 
 == Can I run Kubernetes on Fedora CoreOS?
 
-Yes. However, we envision Fedora CoreOS as not including a specific
-container orchestrator (or version of Kubernetes) by default — just like
-Container Linux and Atomic Host. We will work with the upstream
-Kubernetes community on tools (e.g. kubeadm) and best practices for
-installing Kubernetes on Fedora CoreOS.
+Yes. However, Fedora CoreOS does not include a specific container
+orchestrator (or version of Kubernetes) by default.
 
 == How do I run custom applications on Fedora CoreOS?
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -12,11 +12,8 @@ updated.
 Fedora CoreOS is an automatically updating, minimal, monolithic,
 container-focused operating system, designed for clusters but also
 operable standalone, optimized for Kubernetes but also great without it.
-It aims to combine the best of both CoreOS Container Linux and Fedora
-Atomic Host, integrating technology like Ignition from Container Linux
-with rpm-ostree and SELinux hardening from Project Atomic. Its goal is
-to provide the best container host to run containerized workloads
-securely and at scale.
+Its goal is to provide the best container host to run containerized
+workloads securely and at scale.
 
 == How does Fedora CoreOS relate to RHEL CoreOS?
 
@@ -47,7 +44,7 @@ If you think you have found a problem with Fedora CoreOS, file an issue in our h
 
 Fedora CoreOS artifacts are available at https://fedoraproject.org/en/coreos/download/[fedoraproject.org].
 
-== Does Fedora CoreOS embrace the Container Linux Update Philosophy?
+== Does Fedora CoreOS update itself automatically?
 
 Yes, Fedora CoreOS comes with automatic
 updates and regular releases. Multiple update channels are provided
@@ -57,9 +54,7 @@ can be optionally self-hosted.
 
 == How are Fedora CoreOS nodes provisioned? Can I re-use existing cloud-init configurations?
 
-Fedora CoreOS is provisioned with Ignition. However, existing
-Ignition configurations will require changes, as the OS configuration
-will be different from Container Linux. Existing cloud-init
+Fedora CoreOS is provisioned with Ignition. Existing cloud-init
 configurations are not supported and will need to be migrated into their
 Ignition equivalent.
 
@@ -100,16 +95,14 @@ included by default. Instead, it is recommended to use the `toolbox` utility.
 
 xref:debugging-with-toolbox.adoc[Debugging with Toolbx].
 
-== How do I coordinate cluster-wide OS updates? Is locksmith or the Container Linux Update Operator available for Fedora CoreOS?
+== How do I coordinate cluster-wide OS updates?
 
-The `etcd-lock` feature from https://github.com/coreos/locksmith[locksmith] has
-been directly ported to Zincati, as a https://coreos.github.io/zincati/usage/updates-strategy/#lock-based-strategy[lock-based updates strategy].
-It has also been augmented to support multiple backends, not being anymore
-constrained to etcd2 only.
+The Zincati update manager includes a
+https://coreos.github.io/zincati/usage/updates-strategy/#lock-based-strategy[lock-based updates strategy]
+that supports multiple backends.
 
-The capabilities of https://github.com/coreos/container-linux-update-operator[Container Linux Update Operator (CLUO)]
-have been embedded into the https://github.com/openshift/machine-config-operator[Machine Config Operator (MCO)],
-which is a core component of OKD.
+OKD's https://github.com/openshift/machine-config-operator[Machine Config Operator (MCO)]
+automatically handles updates of Fedora CoreOS in OKD clusters.
 The MCO additionally covers reconciliation of machine configuration changes.
 
 == How do I upload Fedora CoreOS to private AWS EC2 regions?
@@ -138,8 +131,7 @@ It is worth noting that in Fedora CoreOS we have `docker.service`
 disabled by default but it is easily started if anything communicates
 with the `/var/run/docker.sock` because `docker.socket` is enabled by
 default. This means that if a user runs any `docker` command (via
-`sudo docker`) then the daemon will be activated. We did this to make
-the transition easier for users of Container Linux.
+`sudo docker`) then the daemon will be activated.
 
 In https://github.com/coreos/fedora-coreos-tracker/issues/408[coreos/fedora-coreos-tracker#408]
 it was pointed out that because of socket activation users who are

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -3,7 +3,6 @@
 image::welcomefedoracoreos.jpg[]
 
 Fedora CoreOS is an automatically updating, minimal, monolithic, container-focused operating system, designed for clusters but also operable standalone, optimized for Kubernetes but also great without it.
-It aims to combine the best of both CoreOS Container Linux and Fedora Atomic Host, integrating technology like Ignition from Container Linux with rpm-ostree and SELinux hardening from Project Atomic.
 Its goal is to provide the best container host to run containerized workloads securely and at scale.
 
 Fedora CoreOS is an open source project associated with the link:https://fedoraproject.org/[Fedora Project].

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -577,7 +577,7 @@ The EFI-SYSTEM partition can be deleted or reformatted when BIOS booting. Simila
 
 == Mounted Filesystems
 
-Fedora CoreOS uses OSTree, which is a system for managing multiple bootable operating system trees that share storage. This is distinct from e.g. Container Linux which used a dual partition system. In Fedora CoreOS each operating system version is part of the `/` filesystem. All deployments share the same `/var` which can be on the same filesystem, or mounted separately.
+Fedora CoreOS uses OSTree, which is a system for managing multiple bootable operating system trees that share storage. Each operating system version is part of the `/` filesystem. All deployments share the same `/var` which can be on the same filesystem, or mounted separately.
 
 This shows the default mountpoints for a Fedora CoreOS system installed on a `/dev/vda` disk:
 


### PR DESCRIPTION
Container Linux, Atomic Host, and Project Atomic are long gone, and the FAQ is pretty 2018.  Drop references to the former and do an edit pass over the latter.

Fixes https://github.com/coreos/fedora-coreos-docs/issues/292.