### PR TITLE
faq: drop stray remnant of additional hierarchy

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -38,9 +38,7 @@ There is a community meeting that happens every week. See the https://calendar.f
 
 If you think you have found a problem with Fedora CoreOS, file an issue in our https://github.com/coreos/fedora-coreos-tracker/issues[issue tracker].
 
-== Technical FAQ
-
-=== Where can I download Fedora CoreOS?
+== Where can I download Fedora CoreOS?
 
 Fedora CoreOS artifacts are available at https://fedoraproject.org/en/coreos/download/[fedoraproject.org].
 


### PR DESCRIPTION
The "Technical FAQ" heading has been orphaned ever since it was first introduced in 53dd5f8bfa.  Remove it.