### PR TITLE
docs/aws : incite to delete the config after 1st boot

### DIFF
--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -128,3 +128,5 @@ aws s3 rb s3://$NAME-infra
 NOTE: The instance's user data cannot be modified without stopping the instance.
 If you need to have secrets in your ignition configuration you should store it into a s3 bucket and have a minimal configuration in user-data.
 Make sure to clear the s3 bucket when the first boot is completed.
+
+See the https://coreos.github.io/ignition/operator-notes/#secrets[ignition documentation] for more advice on secret management.

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -60,7 +60,7 @@ You now should be able to SSH into the instance using the associated IP address.
 ssh core@<ip address>
 ----
 
-==== Remote ignition configuration
+== Remote ignition configuration
 
 As user-data is limited to 16 KB, you may need to use an external source for your ignition configuration.
 A common solution is to upload the config to a S3 bucket, as the following steps show:
@@ -76,8 +76,8 @@ aws s3 mb s3://$NAME-infra
 .Upload the ignition file
 ----
 NAME='instance1'
-USERDATA='/path/to/config.ign' # path to your Ignition config
-aws s3 cp $USERDATA s3://$NAME-infra/bootstrap.ign
+CONFIG='/path/to/config.ign' # path to your Ignition config
+aws s3 cp CONFIG s3://$NAME-infra/bootstrap.ign
 ----
 
 You can verify the file have been correctly uploaded:
@@ -101,3 +101,30 @@ ignition:
 ----
 
 Then you can launch the instance using the same command as xref:#_customized_example[], passing the minimal configuration you just created.
+
+Once the first boot is completed, make sure to delete the configuration as it may contain sensitive data.
+See xref:#_configuration_cleanup[].
+
+== Configuration cleanup
+
+Once the instance have completed the first boot, we recommend cleaning up the configuration files.
+Any container running on the instance could be able to read the config, raising security concerns.
+
+[source,bash]
+.Deleting the Ignition configuration from the s3 bucket
+----
+NAME='instance1'
+aws s3 rm CONFIG s3://$NAME-infra/bootstrap.ign
+----
+
+Optionnally, you can delete the whole bucket:
+[source,bash]
+.Deleting the s3 bucket
+----
+NAME='instance1'
+aws s3 rb s3://$NAME-infra
+----
+
+NOTE: The instance's user data cannot be modified without stopping the instance.
+If you need to have secrets in your ignition configuration you should store it into a s3 bucket and have a minimal configuration in user-data.
+Make sure to clear the s3 bucket when the first boot is completed.

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -60,7 +60,7 @@ You now should be able to SSH into the instance using the associated IP address.
 ssh core@<ip address>
 ----
 
-== Remote ignition configuration
+== Remote Ignition configuration
 
 As user-data is limited to 16 KB, you may need to use an external source for your ignition configuration.
 A common solution is to upload the config to a S3 bucket, as the following steps show:
@@ -107,9 +107,9 @@ See xref:#_configuration_cleanup[].
 
 == Configuration cleanup
 
-If you need to have secrets in your ignition configuration you should store it into a S3 bucket and have a minimal configuration in user-data.
+If you need to have secrets in your Ignition configuration you should store it into a S3 bucket and have a minimal configuration in user-data.
 Once the instance has completed the first boot, clear the S3 bucket as any process or container running on the instance could access it.
-See the https://coreos.github.io/ignition/operator-notes/#secrets[ignition documentation] for more advice on secret management.
+See the https://coreos.github.io/ignition/operator-notes/#secrets[Ignition documentation] for more advice on secret management.
 
 [source,bash]
 .Deleting the Ignition configuration from the s3 bucket

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -107,8 +107,9 @@ See xref:#_configuration_cleanup[].
 
 == Configuration cleanup
 
-Once the instance have completed the first boot, we recommend cleaning up the configuration files.
-Any container running on the instance could be able to read the config, raising security concerns.
+If you need to have secrets in your ignition configuration you should store it into a S3 bucket and have a minimal configuration in user-data.
+Once the instance has completed the first boot, clear the S3 bucket as any process or container running on the instance could access it.
+See the https://coreos.github.io/ignition/operator-notes/#secrets[ignition documentation] for more advice on secret management.
 
 [source,bash]
 .Deleting the Ignition configuration from the s3 bucket
@@ -124,9 +125,4 @@ Optionnally, you can delete the whole bucket:
 NAME='instance1'
 aws s3 rb s3://$NAME-infra
 ----
-
 NOTE: The instance's user data cannot be modified without stopping the instance.
-If you need to have secrets in your ignition configuration you should store it into a s3 bucket and have a minimal configuration in user-data.
-Make sure to clear the s3 bucket when the first boot is completed.
-
-See the https://coreos.github.io/ignition/operator-notes/#secrets[ignition documentation] for more advice on secret management.


### PR DESCRIPTION

The configuraton may contains sensitive data. As any subsequent container may be able to access the s3 bucket it is advised to clear it. See https://github.com/coreos/fedora-coreos-docs/issues/306