### PR TITLE
provisioning/kubevirt: add persistent disk example

### DIFF
--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -18,12 +18,12 @@ The image for each stream can directly be referenced from the official registry:
 - `quay.io/fedora/fedora-coreos-kubevirt:testing`
 - `quay.io/fedora/fedora-coreos-kubevirt:next`
 
-== Launching a VM instance
+== Launching a virtual machine
 
-Given the `quay.io/fedora/fedora-coreos-kubevirt` images you can create a VMI defnition and combine that with an Ignition config to launch a machine.
+Given the `quay.io/fedora/fedora-coreos-kubevirt` images you can create a VM definition and combine that with an Ignition config to launch a machine.
 
-In the example below, the Ignition config stored in local file `example.ign` is exposed to the VMI via a Kubernetes Secret.
-Learn about various ways to expose userdata to VMIs in the https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#startup-scripts[KubeVirt user guide].
+In the example below, the Ignition config stored in local file `example.ign` is exposed to the VM via a Kubernetes Secret.
+Learn about various ways to expose userdata to VMs in the https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#startup-scripts[KubeVirt user guide].
 
 NOTE: If the user prefers, they can use `oc` instead of `kubectl` in the following commands.
 
@@ -37,36 +37,40 @@ kubectl create secret generic ignition-payload --from-file=userdata=example.ign
 [source, bash]
 ----
 STREAM="stable" # or "testing" or "next"
-cat <<END > vmi.yaml
+cat <<END > vm.yaml
 ---
 apiVersion: kubevirt.io/v1
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
   name: my-fcos
 spec:
-  domain:
-    devices:
-      disks:
-      - disk:
-          bus: virtio
-        name: containerdisk
-      - disk:
-          bus: virtio
-        name: cloudinitdisk
-      rng: {}
-    resources:
-      requests:
-        memory: 2048M
-  volumes:
-  - containerDisk:
-      image: quay.io/fedora/fedora-coreos-kubevirt:${STREAM}
-    name: containerdisk
-  - name: cloudinitdisk
-    cloudInitConfigDrive:
-      secretRef:
-        name: ignition-payload
+  runStrategy: Always
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: containerdisk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+          rng: {}
+        resources:
+          requests:
+            memory: 2048M
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: quay.io/fedora/fedora-coreos-kubevirt:${STREAM}
+          imagePullPolicy: Always
+      - name: cloudinitdisk
+        cloudInitConfigDrive:
+          secretRef:
+            name: ignition-payload
 END
-kubectl create -f vmi.yaml
+kubectl create -f vm.yaml
 ----
 
 Now you should be able to SSH into the instance. If you didn't change the defaults, the

--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -18,20 +18,22 @@ The image for each stream can directly be referenced from the official registry:
 - `quay.io/fedora/fedora-coreos-kubevirt:testing`
 - `quay.io/fedora/fedora-coreos-kubevirt:next`
 
-== Launching a virtual machine
+== Creating an Ignition config secret
 
-Given the `quay.io/fedora/fedora-coreos-kubevirt` images you can create a VM definition and combine that with an Ignition config to launch a machine.
-
-In the example below, the Ignition config stored in local file `example.ign` is exposed to the VM via a Kubernetes Secret.
-Learn about various ways to expose userdata to VMs in the https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#startup-scripts[KubeVirt user guide].
-
-NOTE: If the user prefers, they can use `oc` instead of `kubectl` in the following commands.
+There are various ways to expose userdata to Kubevirt VMs that are covered in the https://kubevirt.io/user-guide/virtual_machines/startup_scripts/#startup-scripts[KubeVirt user guide]. In this example we'll use the Ignition config stored in local file `example.ign` to create a secret named `ignition-payload`. We'll then use this secret when defining our virtual machine in the examples below.
 
 .Creating the secret
 [source, bash]
 ----
 kubectl create secret generic ignition-payload --from-file=userdata=example.ign
 ----
+
+NOTE: If the user prefers, they can use `oc` instead of `kubectl` in the commands throughout this guide.
+
+
+== Launching a virtual machine
+
+Given the `quay.io/fedora/fedora-coreos-kubevirt` images you can create a VM definition and combine that with the Ignition secret reference to launch a virtual machine.
 
 .Launching a VM instance referencing the secret
 [source, bash]

--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -84,6 +84,74 @@ username is `core`.
 virtctl ssh core@my-fcos
 ----
 
+== Launching a virtual machine with persistent storage
+
+The above example will give you a VM that will lose any changes made to it if it is stopped and started again. You can instruct the cluster to import a containerdisk into a Physical Volume when provisioning in order to have virtual machine will have persistence of the OS disk across stop/start operations.
+
+The positive to this approach is that the machine behaves much more like a traditional virtual machine. The drawback is that the cluster needs to offer Block PV storage and not all clusters may do that.
+
+NOTE: You may have to specify a `storageClassName` parameter in the `spec.dataVolumeTemplates.spec.storage` section of the config if your cluster doesn't offer a default. See the https://kubevirt.io/api-reference/v1.0.0/definitions.html#_v1beta1_storagespec[API docs].
+
+.Launching a VM with persistent storage
+[source, bash]
+----
+STREAM="stable" # or "testing" or "next"
+DISK=10
+cat <<END > vm.yaml
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-fcos
+spec:
+  runStrategy: Always
+  dataVolumeTemplates:
+  - metadata:
+      name: fcos-os-disk-volume
+    spec:
+      source:
+        registry:
+          url:
+           docker://quay.io/fedora/fedora-coreos-kubevirt:${STREAM}
+      storage:
+        volumeMode: Block
+        resources:
+          requests:
+            storage: ${DISK}Gi
+        accessModes:
+          - ReadWriteOnce
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - name: fcos-os-disk
+            disk:
+              bus: virtio
+          - name: cloudinitdisk
+            disk:
+              bus: virtio
+            name: cloudinitdisk
+          rng: {}
+        resources:
+          requests:
+            memory: 2048M
+      volumes:
+      - name: fcos-os-disk
+        dataVolume:
+          name: fcos-os-disk-volume
+      - name: cloudinitdisk
+        cloudInitConfigDrive:
+          secretRef:
+            name: ignition-payload
+END
+kubectl create -f vm.yaml
+----
+
+NOTE: The data volume import into the PVC from the container registry may take some time. You can monitor the import by watching the logs of the `importer-fcos-os-disk-volume` pod.
+
+After the machine is up you can connect to it using `virtctl` as shown in the previous example.
+
 == Mirroring the image for use in private registries
 
 If a private registry in air-gapped installations is used, the image can be mirrored to that registry using https://github.com/containers/skopeo[`skopeo`].


### PR DESCRIPTION
A user ran into an issue where the way kubevirt containerdisks work wasn't really matching their mental model for a VM (see https://discussion.fedoraproject.org/t/how-to-install-a-service-in-fedora-coreos/88666/6).

Let's enhance the docs here.