### PR TITLE
Only mention Matrix channel as chat room

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,9 +1,9 @@
 = Fedora CoreOS Frequently Asked Questions
 
 If you have other questions than are mentioned here or want to discuss
-further, join us in our Libera.Chat IRC channel,
-link:ircs://irc.libera.chat:6697/#fedora-coreos[#fedora-coreos], or on our
-https://discussion.fedoraproject.org/c/server/coreos[discussion board].
+further, join us in our Matrix room,
+link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[#coreos:fedoraproject.org],
+or on our https://discussion.fedoraproject.org/c/server/coreos[discussion board].
 Please refer back here as some questions and answers will likely get
 updated.
 
@@ -27,11 +27,11 @@ with the platform.
 
 We have the following new communication channels around Fedora CoreOS:
 
-* mailing list: https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[coreos@lists.fedoraproject.org]
-* operational notices for Fedora CoreOS: https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/[coreos-status@lists.fedoraproject.org]
-* IRC: link:ircs://irc.libera.chat:6697/#fedora-coreos[#fedora-coreos on Libera.Chat]
-* forum at https://discussion.fedoraproject.org/tag/coreos
-* website at https://fedoraproject.org/coreos/
+* Mailing list: https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[coreos@lists.fedoraproject.org]
+* Operational notices for Fedora CoreOS: https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/[coreos-status@lists.fedoraproject.org]
+* Matrix: https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[#coreos:fedoraproject.org]
+* Forum at https://discussion.fedoraproject.org/tag/coreos
+* Website at https://fedoraproject.org/coreos/
 * Twitter at https://twitter.com/fedoracoreos[@fedoracoreos] (Fedora CoreOS news), https://twitter.com/fedora[@fedora] (all Fedora and other relevant news)
 
 There is a community meeting that happens every week. See the https://calendar.fedoraproject.org/CoreOS/[Fedora CoreOS fedocal] for the most up-to-date information.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -3,7 +3,7 @@
 If you have other questions than are mentioned here or want to discuss
 further, join us in our Matrix room,
 link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[#coreos:fedoraproject.org],
-or on our https://discussion.fedoraproject.org/c/server/coreos[discussion board].
+or on our https://discussion.fedoraproject.org/tag/coreos[discussion board].
 Please refer back here as some questions and answers will likely get
 updated.
 

--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -50,6 +50,6 @@ We recommend that all users subscribe to the low-volume https://lists.fedoraproj
 
 Bugs can be reported to the https://github.com/coreos/fedora-coreos-tracker[Fedora CoreOS Tracker].
 
-For live questions, feel free to reach out on the `#fedora-coreos` IRC channel on Libera.Chat.
+For live questions, feel free to reach out in the https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[#coreos:fedoraproject.org room on Matrix].
 
 For doubts and longer discussions related to Fedora CoreOS, a https://discussion.fedoraproject.org/tag/coreos[forum] and a https://lists.fedoraproject.org/archives/list/coreos@lists.fedoraproject.org/[mailing list] are available.

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ Fedora CoreOS is an open source project associated with the link:https://fedorap
 [NOTE]
 ====
 Please refer to the xref:faq.adoc[FAQ] for more information.
-If you want to help or ask any questions, join the link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[Matrix room], or join our link:https://discussion.fedoraproject.org/c/server/coreos[discussion board].
+If you want to help or ask any questions, join the link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[Matrix room], or join our link:https://discussion.fedoraproject.org/tag/coreos[discussion board].
 ====
 
 xref:getting-started.adoc[Get started using Fedora CoreOS!]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -10,7 +10,7 @@ Fedora CoreOS is an open source project associated with the link:https://fedorap
 [NOTE]
 ====
 Please refer to the xref:faq.adoc[FAQ] for more information.
-If you want to help or ask any questions, join the link:ircs://irc.libera.chat:6697/#fedora-coreos[IRC channel], or join our link:https://discussion.fedoraproject.org/c/server/coreos[discussion board].
+If you want to help or ask any questions, join the link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[Matrix room], or join our link:https://discussion.fedoraproject.org/c/server/coreos[discussion board].
 ====
 
 xref:getting-started.adoc[Get started using Fedora CoreOS!]

--- a/modules/ROOT/pages/tutorial-setup.adoc
+++ b/modules/ROOT/pages/tutorial-setup.adoc
@@ -4,7 +4,7 @@ The following tutorials are focused on helping you get started with Fedora CoreO
 
 If you don't know what Fedora CoreOS is, you can refer to the xref:faq.adoc[FAQ] for more information.
 
-NOTE: If you need any help or need to ask any questions while going through those tutorials, please join the link:ircs://irc.libera.chat:6697/#fedora-coreos[IRC channel], or join our https://discussion.fedoraproject.org/tag/coreos[discussion board]. If you find any issue in the tutorial, please report them in the https://github.com/coreos/fedora-coreos-docs/issues[fedora-coreos-docs issue tracker].
+NOTE: If you need any help or need to ask any questions while going through those tutorials, please join the link:https://chat.fedoraproject.org/#/room/#fedora:fedoraproject.org[Matrix room], or join our https://discussion.fedoraproject.org/tag/coreos[discussion board]. If you find any issue in the tutorial, please report them in the https://github.com/coreos/fedora-coreos-docs/issues[fedora-coreos-docs issue tracker].
 
 You should start with the setup instructions from this page as they must be completed first to be able to follow the tutorials.
 


### PR DESCRIPTION
We'd like to direct all communications to the Matrix channel going forward, so let's drop mentions of the IRC channel.

Related: https://github.com/coreos/fedora-coreos-tracker/issues/1566