### PR TITLE
provisioning-openstack: some minor tweaks

### DIFF
--- a/modules/ROOT/pages/provisioning-openstack.adoc
+++ b/modules/ROOT/pages/provisioning-openstack.adoc
@@ -45,7 +45,7 @@ Verify the download, following the instructions on that page, and decompress it.
 ----
 FILE=fedora-coreos-XX.XXXXXXXX.X.X-openstack.x86_64.qcow2
 IMAGE=${FILE:0:-6} # pull off .qcow2
-openstack image create --disk-format=qcow2 --min-disk=10 --min-ram=2 --file=$FILE $IMAGE
+openstack image create --disk-format=qcow2 --min-disk=10 --min-ram=2 --progress --file=$FILE $IMAGE
 ----
 
 NOTE: If you're uploading an `aarch64` disk image then add `--property architecture=aarch64`.
@@ -55,6 +55,8 @@ NOTE: If you're uploading an `aarch64` disk image then add `--property architect
 ----
 openstack image list --name=$IMAGE
 ----
+
+Once the image is listed as `active`, it's ready to be used.
 
 == Launching a VM instance
 
@@ -85,9 +87,12 @@ openstack server create            \
 NOTE: Specifying `--key-name` is optional if you provide an SSH key in your Ignition config.
 
 TIP: Monitor progress of the instance creation with `openstack server show $INSTANCE_NAME`.
+You can also use the `--wait` parameter when calling `openstack server create` to block
+until the instance is active.
 
-Next, if you'd like to SSH into the instance from outside the
-OpenStack environment, you can assign a public IP to the instance:
+Next, if the instance's network isn't externally facing and you'd like to SSH
+into it from outside the OpenStack environment, you will have to assign a public
+IP to the instance:
 
 .Create and Assign a Floating IP
 [source, bash]


### PR DESCRIPTION
A few user-friendly tweaks for anyone not very familiar with OpenStack.
1. Add `--progress` to `openstack image create` to get a progress bar of the upload.
2. Note that the image is ready to use when it's in the `active` state.
3. Mention `--wait` parameter in instance launching tips.
4. Tweak the floating IP section so it's clearer that you don't have to do this if the instance's network is already externally accessible.