### PR TITLE
Customize NIC: Fix documentation

### DIFF
--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -36,7 +36,7 @@ storage:
       mode: 0644
       contents:
         inline: |
-          SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="12:34:56:78:9a:bc", ATTR{type}=="1", NAME="infra"'
+          SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="12:34:56:78:9a:bc", ATTR{type}=="1", NAME="infra"
 ----
 
 == Networking in the Initramfs via Kernel Arguments


### PR DESCRIPTION
There is a single quote in the butane configuration, which is causing the udev rule to fail.