### PR TITLE
provisioning-digitalocean: fix command to wait for image availability

### DIFF
--- a/modules/ROOT/pages/provisioning-digitalocean.adoc
+++ b/modules/ROOT/pages/provisioning-digitalocean.adoc
@@ -25,7 +25,7 @@ Fedora CoreOS is designed to be updated automatically, with different schedules 
 ----
 doctl compute image create my-fcos-image --region sfo2 --image-url <download-url>
 # Wait for image creation to finish
-while ! doctl compute image list-user | grep my-fcos-image; do sleep 5; done
+while ! doctl compute image list-user --output json | jq -c '.[] | select(.name=="my-fcos-image")' | grep available; do sleep 5; done
 ----
 
 === Launching a droplet


### PR DESCRIPTION
#closes https://github.com/coreos/fedora-coreos-tracker/issues/1586