### PR TITLE
provisioning/rpi4: update rpi-u-boot.bin name

### DIFF
--- a/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
+++ b/modules/ROOT/pages/provisioning-raspberry-pi4.adoc
@@ -48,7 +48,7 @@ WARNING: The following commands to extract the contents of the RPMs, the use of 
 [source, bash]
 ----
 for rpm in /tmp/RPi4boot/*rpm; do rpm2cpio $rpm | sudo cpio -idv -D /tmp/RPi4boot/; done
-sudo mv /tmp/RPi4boot/usr/share/uboot/rpi_4/u-boot.bin /tmp/RPi4boot/boot/efi/rpi4-u-boot.bin
+sudo mv /tmp/RPi4boot/usr/share/uboot/rpi_4/u-boot.bin /tmp/RPi4boot/boot/efi/rpi-u-boot.bin
 ----
 
 Run `coreos-installer` to install to the target disk. There are https://coreos.github.io/coreos-installer/getting-started/[various ways] to run `coreos-installer` and install to a target disk. We won't cover them all here, but this workflow most closely mirrors the xref:bare-metal.adoc#_installing_from_the_container["Installing from the container"] documentation.


### PR DESCRIPTION
As of FC38, `bcm283x-firmware`'s `config.txt` refers to a single `rpi-u-boot.bin` instead of different files for each RPi variant as in FC37, changed in this commit: https://src.fedoraproject.org/rpms/bcm283x-firmware/c/489ba9a1607d29ed171540a675a43e71aa0d1f37

Copying the u-boot bin file to the correct location makes this document possible to follow for FC38+.