### PR TITLE
Use an attribute for the latest version of the Butane spec & minor style fix

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,3 +11,4 @@ asciidoc:
     stable-version: 39.20240112.3.0
     ignition-version: 2.17.0
     butane-version: 0.19.0
+    butane-latest-stable-spec: 0.15.0

--- a/modules/ROOT/pages/alternatives.adoc
+++ b/modules/ROOT/pages/alternatives.adoc
@@ -4,10 +4,10 @@ Due to an https://github.com/fedora-sysv/chkconfig/issues/9[ongoing issue] in ho
 
 Instead, until this issue is resolved, you can set the symlinks directly in `/etc/alternatives`. For example, to use the legacy-based variants of the `iptables` commands:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   links:
     - path: /etc/alternatives/iptables

--- a/modules/ROOT/pages/authentication.adoc
+++ b/modules/ROOT/pages/authentication.adoc
@@ -10,10 +10,10 @@ If you do not want to use Ignition to manage the default user's SSH key(s), you 
 
 To create a new user (or users), add it to the `users` list of your Butane config. In the following example, the config creates two new usernames, but doesn't configure them to be especially useful.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: jlebon
@@ -26,10 +26,10 @@ You will typically want to configure SSH keys or a password, in order to be able
 
 To configure an SSH key for a local user, you can use a Butane config:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core
@@ -50,10 +50,10 @@ Depending on the configuration variant and version you use, you can use local fi
 of inlining them.
 The example from the xref:#_using_an_ssh_key[previous section] can thus be rewritten as follows:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core
@@ -97,10 +97,10 @@ To view and validate the effective configuration for sshd, two test modes (`-t`,
 
 Fedora CoreOS ships with no default passwords. You can use a Butane config to set a password for a local user. Building on the previous example, we can configure the `password_hash` for one or more users:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core
@@ -135,10 +135,10 @@ Fedora CoreOS comes with a few groups configured by default: `root`, `adm`, `whe
 
 When configuring users via Butane configs, we can specify groups that the user(s) should be a part of.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core
@@ -161,10 +161,10 @@ passwd:
 
 If a group does not exist, users should create them as part of the Butane config.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   groups:
     - name: engineering
@@ -195,10 +195,10 @@ passwd:
 
 The easiest way for users to be granted administrative privileges is to have them added to the `sudo` and `wheel` groups as part of the Butane config.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   groups:
     - name: engineering
@@ -231,10 +231,10 @@ passwd:
 
 To enable password authentication via SSH, add the following to your Butane config:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/ssh/sshd_config.d/20-enable-passwords.conf

--- a/modules/ROOT/pages/auto-updates.adoc
+++ b/modules/ROOT/pages/auto-updates.adoc
@@ -17,10 +17,10 @@ In order to receive updates very early in the phased rollout cycle, a node can b
 This can be done during provisioning by using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: configuring Zincati rollout wariness
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/zincati/config.d/51-rollout-wariness.toml
@@ -46,10 +46,10 @@ A specific finalization strategy can be configured on each node.
 The xref:producing-ign.adoc[Butane] snippet below shows how to define two maintenance windows during weekend days, starting at 22:30 UTC and lasting one hour each:
 
 .Example: configuring Zincati updates strategy
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/zincati/config.d/55-updates-strategy.toml

--- a/modules/ROOT/pages/bootloader-updates.adoc
+++ b/modules/ROOT/pages/bootloader-updates.adoc
@@ -34,10 +34,10 @@ Updated: grub2-efi-x64-1:2.04-31.fc33.x86_64,shim-x64-15-8.x86_64
 ----
 
 .Example systemd unit to automate bootupd updates
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: custom-bootupd-auto.service

--- a/modules/ROOT/pages/counting.adoc
+++ b/modules/ROOT/pages/counting.adoc
@@ -15,10 +15,10 @@ $ sudo systemctl mask --now rpm-ostree-countme.timer
 
 You can use the following Butane config to disable counting during provisioning on first boot:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: rpm-ostree-countme.timer

--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -6,10 +6,10 @@ You can create a systemd https://www.freedesktop.org/software/systemd/man/system
 For example, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", place a systemd link file at `/etc/systemd/network/25-infra.link` using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: Customize NIC via systemd Link File
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/systemd/network/25-infra.link
@@ -26,10 +26,10 @@ storage:
 Similarly, also through Ignition configs, to name NIC with the MAC address `12:34:56:78:9a:bc` to "infra", create a https://man7.org/linux/man-pages/man7/udev.7.html[udev rule] at `/etc/udev/rules.d/80-ifname.rules` using the xref:producing-ign.adoc[Butane] config snippet shown below:
 
 .Example: Customize NIC via Udev Rules
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/udev/rules.d/80-ifname.rules

--- a/modules/ROOT/pages/debugging-kernel-crashes.adoc
+++ b/modules/ROOT/pages/debugging-kernel-crashes.adoc
@@ -9,10 +9,10 @@ By default, the vmcore will be saved in `/var/crash`. It is also possible to wri
 
 == Configuring kdump via Ignition
 .Example kdump configuration
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 kernel_arguments:
   should_exist:
   - 'crashkernel=300M'

--- a/modules/ROOT/pages/emergency-shell.adoc
+++ b/modules/ROOT/pages/emergency-shell.adoc
@@ -34,10 +34,10 @@ This will configure both the GRUB bootloader and the kernel to use the specified
 If you are launching FCOS from an image (in a cloud or a virtual machine), you can use Ignition to configure the console at provisioning time.
 
 .Example: Enabling primary serial and secondary graphical console
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 kernel_arguments:
   should_exist:
     # Order is significant, so group both arguments into the same list entry.

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -140,10 +140,10 @@ To prevent making this mistake you can disable `docker` completely by
 masking the `docker.service` systemd unit.
 
 .Example Butane config for disabling docker.service
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: docker.service
@@ -211,10 +211,10 @@ We don't recommend it, but if you really want to use it you can just
 unmask and enable it:
 
 .Example Butane config for unmasking dnsmasq.service
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: dnsmasq.service
@@ -262,10 +262,10 @@ modifications dynamically. For example, for an SELinux boolean you can use the
 following systemd unit that executes on every boot:
 
 .Example Butane config for dynamically applying SELinux boolean
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: setsebool.service

--- a/modules/ROOT/pages/grub-password.adoc
+++ b/modules/ROOT/pages/grub-password.adoc
@@ -20,10 +20,10 @@ NOTE: `grub2-mkpasswd-pbkdf2` tool is a component of the `grub2-tools-minimal` p
 
 With the password hash ready, you can now create the Butane config.
 
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 grub:
   users:
     - name: root

--- a/modules/ROOT/pages/hostname.adoc
+++ b/modules/ROOT/pages/hostname.adoc
@@ -2,10 +2,10 @@
 
 To set a custom hostname for your system, use the following Butane config to write to `/etc/hostname`:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/hostname

--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -8,10 +8,10 @@ You can specify kernel arguments in a Butane config using the `kernel_arguments`
 
 Starting from June 2021, cgroups v2 is the default on new installations of Fedora CoreOS. Here's an example `kernelArguments` section which adds the `systemd.unified_cgroup_hierarchy=0` kernel argument so that the machine keeps using cgroups v1:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 kernel_arguments:
   should_exist:
     - systemd.unified_cgroup_hierarchy=0
@@ -21,10 +21,10 @@ kernel_arguments:
 
 Here's an example `kernelArguments` section which switches `mitigations=auto,nosmt` to `mitigations=off` to disable all CPU vulnerability mitigations:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 kernel_arguments:
   should_exist:
     - mitigations=off

--- a/modules/ROOT/pages/live-booting.adoc
+++ b/modules/ROOT/pages/live-booting.adoc
@@ -91,7 +91,7 @@ boot
 
 By default, the Fedora CoreOS live environment does not store any state on disk, and is reprovisioned from scratch on every boot. However, you may choose to store some persistent state (such as container images) in a filesystem that persists across reboots. For example, here's a Butane config that configures a persistent `/var`:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
 version: 1.1.0

--- a/modules/ROOT/pages/major-changes.adoc
+++ b/modules/ROOT/pages/major-changes.adoc
@@ -138,10 +138,10 @@ $ sudo touch /etc/coreos/iptables-legacy.stamp
 
 For new nodes that get deployed between now and when the migration happens, you can create the `/etc/coreos/iptables-legacy.stamp` file using Ignition to ensure they don't get migrated. After the migration, you can bring up new nodes on the legacy backend by manually setting the symbolic links via Ignition. Below is a Butane config that does both of these:
 
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/coreos/iptables-legacy.stamp

--- a/modules/ROOT/pages/managing-files.adoc
+++ b/modules/ROOT/pages/managing-files.adoc
@@ -6,10 +6,10 @@ This example creates a directory with the default mode (set to `0755`: readable
 and recurseable by all), and writable only by the owner (by default `root`).
 
 .Example to create a directory with default ownership and permissions
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   directories:
   - path: /opt/tools
@@ -21,10 +21,10 @@ in-line. It also sets the file mode to `0644` (readable by all, writable by the
 owner) and sets ownership to `dnsmasq:dnsmasq`.
 
 .Example to create a file with in-line content
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /var/helloworld
@@ -46,10 +46,10 @@ is `sha512-` followed by the 128 hex characters given by the sha512sum command.
 The resulting file is made readable and executable by all.
 
 .Example to create a files from a remote source
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /opt/tools/transmogrifier
@@ -67,10 +67,10 @@ This is useful to let local processes invoke a program without altering their
 PATH environment variable.
 
 .Example to create a symbolic link
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   links:
     - path: /usr/local/bin/transmogrifier
@@ -85,10 +85,10 @@ https://github.com/coreos/butane/issues/380[butane#380] for the tracking issue
 in Butane for a future better syntax for this case.
 
 .Example to create directories with specific ownership
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   directories:
     - path: /home/builder/.config

--- a/modules/ROOT/pages/migrate-ah.adoc
+++ b/modules/ROOT/pages/migrate-ah.adoc
@@ -24,10 +24,10 @@ ssh_authorized_keys:
 This can be manually translated into a `passwd` node within the Butane config:
 
 .Example of users:
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -17,10 +17,10 @@ This example shows how to install the fully fledged `vim` text editor and how to
 
 NOTE: In the future, we will have a more Ignition-friendly method of doing this with stronger guarantees. See upstream issues https://github.com/coreos/butane/issues/81[butane#81] and https://github.com/coreos/fedora-coreos-tracker/issues/681[fedora-coreos-tracker#681] for more information.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     # Installing vim as a layered package with rpm-ostree

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -186,10 +186,10 @@ The SSH public key will be provisioned to the Fedora CoreOS machine (via Ignitio
 
 . Copy the following example into a text editor:
 +
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -65,15 +65,15 @@ ssh core@<ip address>
 As user-data is limited to 16 KB, you may need to use an external source for your Ignition configuration.
 A common solution is to upload the config to a S3 bucket, as the following steps show:
 
-[source, bash]
 .Create a new s3 bucket
+[source, bash]
 ----
 NAME='instance1'
 aws s3 mb s3://$NAME-infra
 ----
 
-[source, bash]
 .Upload the Ignition file
+[source, bash]
 ----
 NAME='instance1'
 CONFIG='/path/to/config.ign' # path to your Ignition config
@@ -81,16 +81,18 @@ aws s3 cp CONFIG s3://$NAME-infra/bootstrap.ign
 ----
 
 You can verify the file have been correctly uploaded:
-[source, bash]
+
 .List files in the bucket
+[source, bash]
 ----
 NAME='instance1'
 aws s3 ls s3://$NAME-infra/
 ----
 
 Then create a minimal Ignition config as follows:
-[source,yaml,subs="attributes"]
+
 .Retrieving a remote Ignition file from a s3 bucket
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
 version: {butane-latest-stable-spec}
@@ -111,16 +113,17 @@ If you need to have secrets in your Ignition configuration you should store it i
 Once the instance has completed the first boot, clear the S3 bucket as any process or container running on the instance could access it.
 See the https://coreos.github.io/ignition/operator-notes/#secrets[Ignition documentation] for more advice on secret management.
 
-[source,bash]
 .Deleting the Ignition configuration from the s3 bucket
+[source,bash]
 ----
 NAME='instance1'
 aws s3 rm CONFIG s3://$NAME-infra/bootstrap.ign
 ----
 
 Optionnally, you can delete the whole bucket:
-[source,bash]
+
 .Deleting the s3 bucket
+[source,bash]
 ----
 NAME='instance1'
 aws s3 rb s3://$NAME-infra

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -89,11 +89,11 @@ aws s3 ls s3://$NAME-infra/
 ----
 
 Then create a minimal Ignition config as follows:
-[source,yaml]
+[source,yaml,subs="attributes"]
 .Retrieving a remote Ignition file from a s3 bucket
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     replace:

--- a/modules/ROOT/pages/provisioning-virtualbox.adoc
+++ b/modules/ROOT/pages/provisioning-virtualbox.adoc
@@ -68,10 +68,10 @@ If your Ignition config is larger than this limit, you can host the config on an
 . Upload your Ignition config to an HTTPS server.
 . xref:remote-ign.adoc[Create a Butane pointer config] that specifies the URL of your full Ignition config:
 +
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     replace:

--- a/modules/ROOT/pages/proxy.adoc
+++ b/modules/ROOT/pages/proxy.adoc
@@ -8,10 +8,10 @@ This is best done by defining a single file with required environment variables 
 
 This common file has to be subsequently referenced explicitly by each service that requires internet access thereby encouraging least privilege best practices.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/example-proxy.env
@@ -32,10 +32,10 @@ https://github.com/coreos/zincati[Zincati] polls for OS updates, and https://git
 
 TIP: You may be able to use local file references to systemd units instead of inlining them. See xref:tutorial-services.adoc#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: rpm-ostreed.service
@@ -62,10 +62,10 @@ systemd:
 
 If using docker then the `docker.service` drop-in is sufficient. If running Kubernetes with containerd (and no docker) then the `containerd.service` drop-in may be necessary.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: docker.service
@@ -88,10 +88,10 @@ systemd:
 
 Podman has no daemon and so configuration is for each individual service scheduled, and can be done as part of the full systemd unit definition.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: example-svc.service

--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -7,10 +7,10 @@ The complete list of supported protocols and related options for remote Ignition
 The following examples show how to retrieve an Ignition file from a remote source. They are both set to replace the current configuration with a remote Ignition file.
 
 .Retrieving a remote Ignition file via HTTPS
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     replace:
@@ -18,10 +18,10 @@ ignition:
 ----
 
 .Retrieving a remote Ignition file via HTTPS with a custom certificate authority
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     replace:
@@ -37,10 +37,10 @@ NOTE: The certificate authorities listed here are not automatically added to the
 In some cases, if you need to merge a local configuration and one or several remote ones, you can use the `merge` rather than `replace` in a Butane config.
 
 .Retrieving a remote Ignition file via HTTPS and merging it with the current config
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     merge:
@@ -57,10 +57,10 @@ Retrieving remote Ignition files via plain HTTP is also possible as shown below.
 WARNING: Retrieving a remote Ignition config via HTTP exposes the contents of the config to anyone monitoring network traffic. When using HTTP, it is advisable to use the verification option to ensure the contents haven't been tampered with.
 
 .Retrieving a remote Ignition file via HTTP
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     replace:
@@ -72,10 +72,10 @@ ignition:
 If you need to retrieve a remote Ignition file but have no direct access to the remote host, you can specify a proxy for plain HTTP and/or HTTPS. You can also specify hosts that should be excluded from proxying.
 
 .Retrieving a remote Ignition file via a proxy
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 ignition:
   config:
     merge:

--- a/modules/ROOT/pages/running-containers.adoc
+++ b/modules/ROOT/pages/running-containers.adoc
@@ -9,10 +9,10 @@ The following Butane config snippet configures the systemd `hello.service` to ru
 TIP: You may be able to use local file references to systemd units instead of inlining them. See xref:tutorial-services.adoc#_using_butanes__files_dir_parameter_to_embed_files[Using butane's `--files-dir` Parameter to Embed Files] for more information.
 
 .Example for running busybox using systemd and podman
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: hello.service
@@ -38,10 +38,10 @@ systemd:
 
 https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html[Podman Quadlet] is functionality included in podman that allows starting containers via systemd using a systemd generator. The example below is the same `hello.service` that was previously shown but deployed via the Podman Quadlet functionality.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/containers/systemd/hello.container
@@ -66,10 +66,10 @@ storage:
 https://etcd.io[etcd] is not shipped as part of Fedora CoreOS. To use it, run it as a container, as shown below.
 
 .Butane config for setting up single node etcd
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: etcd-member.service

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -26,10 +26,10 @@ For physical hardware, a good best practice is to reference devices via the `/de
 Here's an example Butane config to set up `/var` on a separate partition on the same primary disk:
 
 .Adding a /var partition to the primary disk
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
   - # The link to the block device the OS was booted from.
@@ -61,10 +61,10 @@ storage:
 You can of course mount only a subset of `/var` into a separate partition. For example, to mount `/var/lib/containers`:
 
 .Adding a /var/lib/containers partition to the primary disk
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
   - device: /dev/disk/by-id/coreos-boot-disk
@@ -87,10 +87,10 @@ storage:
 Alternatively, you can also mount storage from a separate disk. For example, here we mount `/var/log` from a partition on `/dev/vdb`:
 
 .Adding /var/log from a secondary disk
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
   - device: /dev/vdb
@@ -110,10 +110,10 @@ storage:
 .Defining a disk with multiple partitions
 In this example, we wipe the disk and create two new partitions.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
     -
@@ -148,10 +148,10 @@ NOTE: You must have at least 4 GiB of RAM for root reprovisioning to work.
 Here's an example of moving from xfs to ext4, but reusing the same partition on the primary disk:
 
 .Changing the root filesystem to ext4
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   filesystems:
     - device: /dev/disk/by-partlabel/root
@@ -163,10 +163,10 @@ storage:
 Similarly to the previous section, you can also move the root filesystem entirely. Here, we're moving root to a RAID0 device:
 
 .Moving the root filesystem to RAID0
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   raid:
     - name: myroot
@@ -186,10 +186,10 @@ NOTE: You don't need the `path` or `with_mount_unit` keys; FCOS knows that the r
 If you want to replicate the boot disk across multiple drives for resiliency to drive failure, you need to mirror all the default partitions (root, boot, EFI System Partition, and bootloader code). There is special Butane config syntax for this:
 
 .Mirroring the boot disk onto two drives
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 boot_device:
   mirror:
     devices:
@@ -202,10 +202,10 @@ boot_device:
 This example demonstrates the process of creating the filesystem by defining and labeling the partitions, combining them into a RAID array, and formatting that array as ext4.
 
 .Defining a filesystem on a RAID storage device
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
   # This defines two partitions, each on its own disk. The disks are
@@ -248,10 +248,10 @@ storage:
 
 Here is an example to configure a LUKS device at `/var/lib/data`.
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   luks:
     - name: data
@@ -273,10 +273,10 @@ NOTE: You must have at least 4 GiB of RAM for root reprovisioning to work.
 There is simplified Butane config syntax for configuring root filesystem encryption and pinning. Here is an example of using it to create a TPM2-pinned encrypted root filesystem:
 
 .Encrypting the root filesystem with a TPM2 Clevis pin
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 boot_device:
   luks:
     tpm2: true
@@ -285,10 +285,10 @@ boot_device:
 This is equivalent to the following expanded config:
 
 .Encrypting the root filesystem with a TPM2 Clevis pin without using boot_device
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   luks:
     - name: root
@@ -311,10 +311,10 @@ This next example binds the root filesystem encryption to PCR 7 which correspond
 NOTE: Binding for PCR 8 (UEFI Boot Component used to track commands and kernel command line) is not supported as the kernel command line changes with every OS update.
 
 .Encrypting the root filesystem with a TPM2 Clevis pin bound to PCR 7
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   luks:
     - name: root
@@ -346,10 +346,10 @@ $ sudo clevis luks list -d /dev/disk/by-partlabel/root
 Here is an example of the simplified config syntax with Tang:
 
 .Encrypting the root filesystem with a Tang Clevis pin
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 boot_device:
   luks:
     tang:
@@ -364,10 +364,10 @@ NOTE: For more information about setting up a Tang server, see https://github.co
 You can configure both Tang and TPM2 pinning (including multiple Tang servers for redundancy). By default, only the TPM2 device or a single Tang server is needed to unlock the root filesystem. This can be changed using the `threshold` key:
 
 .Encrypting the root filesystem with both TPM2 and Tang pins
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 boot_device:
   luks:
     tang:
@@ -384,10 +384,10 @@ boot_device:
 If you use Ignition to reconfigure or move the root partition, that partition is not automatically grown on first boot (see related discussions in https://github.com/coreos/fedora-coreos-tracker/issues/570[this issue]). In the case of moving the root partition to a new disk (or multiple disks), you should set the desired partition size using the `size_mib` field. If reconfiguring the root filesystem in place, as in the LUKS example above, you can resize the existing partition using the `resize` field:
 
 .Resizing the root partition to its maximum size
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
     - device: /dev/vda
@@ -415,10 +415,10 @@ storage:
 This example creates a swap partition spanning all of the `sdb` device, creates a swap area on it, and creates a systemd swap unit so the swap area is enabled on boot.
 
 .Configuring a swap partition on a second disk
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   disks:
     - device: /dev/sdb
@@ -441,7 +441,7 @@ Fedora CoreOS systems can be configured to mount network filesystems such as NFS
 
 .Creating a systemd unit to mount an NFS filesystem on boot.
 NOTE: The `.mount` file must be named based on the path (e.g. `/var/mnt/data` = `var-mnt-data.mount`)
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
 version: 1.3.0
@@ -463,7 +463,7 @@ systemd:
 ----
 
 .Creating a systemd unit to mount an NFS filesystem when users access the mount point (automount)
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
 version: 1.3.0
@@ -501,10 +501,10 @@ systemd:
 This example configures a mirrored boot disk with a TPM2-encrypted root filesystem, overrides the sizes of the automatically-generated root partition replicas, and adds an encrypted mirrored `/var` partition which consumes the remainder of the disks.
 
 .Encrypted mirrored boot disk with separate /var
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 boot_device:
   luks:
     tpm2: true

--- a/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-swaponzram.adoc
@@ -4,10 +4,10 @@ In Fedora 33 some editions https://www.fedoraproject.org/wiki/Releases/33/Change
 
 The documentation for the config file format lives in the https://github.com/systemd/zram-generator/blob/main/man/zram-generator.conf.md[upstream documentation] along with a comprehensive https://github.com/systemd/zram-generator/blob/main/zram-generator.conf.example[example]. The most basic form of a configuration file that will set up a `zram0` device for swap is:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/systemd/zram-generator.conf

--- a/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
@@ -53,10 +53,10 @@ NOTE: The `wg genpsk` command generates a PresharedKey that can only be used onc
 You can now configure your Ignition config to create the `wg0` configuration file:
 
 .Example FCOS WireGuard configuration
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/wireguard/wg0.conf
@@ -203,10 +203,10 @@ peer: <fcos_public_key>
 If you plan on forwarding all of your client's traffic through the FCOS instance you will need to enable IP Forwarding and you need to set and set some PostUp and PostDown directives:
 
 .Example FCOS WireGuard configuration with IP forwarding
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/sysctl.d/90-ipv4-ip-forward.conf

--- a/modules/ROOT/pages/sysconfig-network-configuration.adoc
+++ b/modules/ROOT/pages/sysconfig-network-configuration.adoc
@@ -105,10 +105,10 @@ Any configuration provided via Ignition will be considered at a higher priority 
 
 An example https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/[Butane] config for the same static networking example that we showed above is:
 
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/ens2.nmconnection
@@ -247,10 +247,10 @@ ip=10.10.10.10::10.10.10.1:255.255.255.0:myhostname:ens2:none:8.8.8.8
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${interface}.nmconnection
@@ -271,10 +271,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/ens2.nmconnection
@@ -317,10 +317,10 @@ bond=bond0:ens2,ens3:mode=active-backup,miimon=100
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${bondname}.nmconnection
@@ -364,10 +364,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/bond0.nmconnection
@@ -432,10 +432,10 @@ bridge=br0:ens2,ens3
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${bridgename}.nmconnection
@@ -476,10 +476,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/br0.nmconnection
@@ -541,10 +541,10 @@ team=team0:ens2,ens3
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${teamname}.nmconnection
@@ -588,10 +588,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/team0.nmconnection
@@ -656,10 +656,10 @@ vlan=ens2.100:ens2
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${interface}.${vlanid}.nmconnection
@@ -701,10 +701,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/ens2.100.nmconnection
@@ -768,10 +768,10 @@ vlan=bond0.100:bond0
 ==== Butane config
 
 .Template
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/${bondname}.${vlanid}.nmconnection
@@ -830,10 +830,10 @@ storage:
 ----
 
 .Rendered
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/system-connections/bond0.100.nmconnection
@@ -897,10 +897,10 @@ By default, FCOS will attempt to autoconfigure (DHCP/SLAAC) on every interface w
 
 
 .Disable NetworkManager autoconfiguration of ethernet devices
-[source, yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/NetworkManager/conf.d/noauto.conf

--- a/modules/ROOT/pages/sysconfig-setting-keymap.adoc
+++ b/modules/ROOT/pages/sysconfig-setting-keymap.adoc
@@ -2,10 +2,10 @@
 
 To set your system keyboard layout (keymap), use the following Butane config to write to `/etc/vconsole.conf`:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/vconsole.conf

--- a/modules/ROOT/pages/sysctl.adoc
+++ b/modules/ROOT/pages/sysctl.adoc
@@ -8,10 +8,10 @@ Persistent settings should be written under `/etc/sysctl.d/` during provisioning
 As an example, the xref:producing-ign.adoc[Butane] snippet below shows how to disable _SysRq_ keys:
 
 .Example: configuring kernel tunable to disable SysRq keys
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /etc/sysctl.d/90-sysrq.conf

--- a/modules/ROOT/pages/time-zone.adoc
+++ b/modules/ROOT/pages/time-zone.adoc
@@ -44,10 +44,10 @@ It is recommended that you set the same time zone across all your machines in th
 
 For example, you can set the time zone to `America/New_York` by using a Butane config like the following:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.4.0
+version: {butane-latest-stable-spec}
 storage:
   links:
     - path: /etc/localtime

--- a/modules/ROOT/pages/tutorial-autologin.adoc
+++ b/modules/ROOT/pages/tutorial-autologin.adoc
@@ -19,10 +19,10 @@ Let's create a very simple Butane config that will perform the following actions
 
 We can create a config file named `autologin.bu` now as:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: serial-getty@ttyS0.service

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -17,10 +17,10 @@ As usual, we will set up console autologin, a hostname, systemd pager configurat
 Similarly to what we did in the second provisioning scenario, we will write the following Butane config in a file called `containers.bu`:
 
 .Example with automatic serial console login, SSH key, and multiple systemd units
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -52,10 +52,10 @@ EOF
 
 We can now create a Butane config that will include the script and systemd unit file contents by picking up the local `public-ipv4.sh` and `issuegen-public-ipv4.service` files using local file references. The final Butane config, stored in `services.bu`, will be:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 systemd:
   units:
     - name: serial-getty@ttyS0.service

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -48,10 +48,10 @@ We will create a Butane config that will:
 
 Let's write this Butane config to a file called `updates.bu`:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -11,10 +11,10 @@ In this tutorial, we will set up a user level systemd unit for an unprivileged u
 
 In this example, we will launch a systemd service for the user `sleeper`. First, let's create a user:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: sleeper
@@ -22,10 +22,10 @@ passwd:
 
 This will also create the home directory for the `sleeper` user. Then we can add the systemd unit:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /home/sleeper/.config/systemd/user/linger-example.service
@@ -44,10 +44,10 @@ storage:
 
 System services can be directly enabled in Butane configs but user level services have to be manually enabled for now:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 storage:
   directories:
     - path: /home/sleeper/.config/systemd/user/default.target.wants
@@ -68,10 +68,10 @@ storage:
 
 We set up lingering for the systemd user level instance so that it gets started directly on boot and stays running:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 storage:
   files:
     - path: /var/lib/systemd/linger/sleeper
@@ -80,10 +80,10 @@ storage:
 
 As the following directories do not exist yet, we will have to create them to tell Ignition to set the right ownership and permissions:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 storage:
   directories:
     - path: /home/sleeper/.config
@@ -116,10 +116,10 @@ storage:
 
 The final Butane config, stored in `user.bu`, will be:
 
-[source,yaml]
+[source,yaml,subs="attributes"]
 ----
 variant: fcos
-version: 1.5.0
+version: {butane-latest-stable-spec}
 passwd:
   users:
     - name: core


### PR DESCRIPTION
Use an attribute for the latest version of the Butane spec

This should make it easier to update all examples in once change and
potentially automate this change.

---

provisioning-aws: Minor style harmonization

Plase source code caption on top of the code blocks.