### PR TITLE
antora.yml: Fix latest Butane spec attribute

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -11,4 +11,4 @@ asciidoc:
     stable-version: 39.20240128.3.0
     ignition-version: 2.17.0
     butane-version: 0.19.0
-    butane-latest-stable-spec: 0.15.0
+    butane-latest-stable-spec: 1.5.0


### PR DESCRIPTION
Fixes: https://github.com/coreos/butane/issues/516
Fixes: https://github.com/coreos/fedora-coreos-docs/pull/612
Fixes: 5c9ec12 Use an attribute for the latest version of the Butane spec