### PR TITLE
Update tutorial with more details

### DIFF
--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -1,6 +1,6 @@
 = Setting up SSH access and starting containers at boot
 
-NOTE: Make sure that you have completed the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial.
+NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have create file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
 
 In this tutorial, we will set up SSH access and start a container at boot. Fedora CoreOS is focused on running applications/services in containers thus we recommend trying to run containers and avoid modifying the host directly. Running containers and keeping a pristine host layer makes automatic updates more reliable and allows for separation of concerns with the Fedora CoreOS team responsible for the OS and end-user operators/sysadmins responsible for the applications.
 

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -1,6 +1,6 @@
 = Launching a user-level systemd unit on boot
 
-NOTE: Make sure that you have completed the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial.
+NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have create file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
 
 In this tutorial, we will set up a user level systemd unit for an unprivileged user. There are times when it's helpful to launch a user-level https://www.freedesktop.org/software/systemd/man/systemd.unit.html[systemd unit] without having to log in. For example, you may wish to launch a container that provides a network service or run an HPC job. For this setup, we will add the following to a Butane config:
 


### PR DESCRIPTION
During the Fedora 40 test day, while testing the [FCOS tutorials](https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/), I noticed that it could be a little bit more clear about required ssh file.  I've included  more details in the note to make it more visible in the related tutorials. This update aims to make the tutorials more beginner-friendly.

**BEFORE**
![image](https://github.com/coreos/fedora-coreos-docs/assets/72117488/8d1defa2-26ea-4c3d-abda-ee193d55b455)
**AFTER**
![image](https://github.com/coreos/fedora-coreos-docs/assets/72117488/51e74465-b8fe-47e8-b144-84488db9472f)
