### PR TITLE
Storage: Increase the size of a mirrored primary partition

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -519,14 +519,16 @@ storage:
         # Override size of root partition on first disk, via the label
         # generated for boot_device.mirror
         - label: root-1
-          size_mib: 8192
+          # Mirroring the boot disk creates root partition smaller than
+          # required 8 GiB, so we increase it to 10 GiB
+          size_mib: 10240
         # Add a new partition filling the remainder of the disk
         - label: var-1
     - device: /dev/sdb
       partitions:
         # Similarly for second disk
         - label: root-2
-          size_mib: 8192
+          size_mib: 10240
         - label: var-2
   raid:
     - name: md-var

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -519,8 +519,6 @@ storage:
         # Override size of root partition on first disk, via the label
         # generated for boot_device.mirror
         - label: root-1
-          # Mirroring the boot disk creates root partition smaller than
-          # required 8 GiB, so we increase it to 10 GiB
           size_mib: 10240
         # Add a new partition filling the remainder of the disk
         - label: var-1


### PR DESCRIPTION
Mirroring the boot disk creates root partitions smaller than required 8 GiB and a warning is emitted on login. Correcting the suggested `size_mib: 8192` to a higher value of `size_mib: 10240` in the boot disk mirroring sections of the docs would be helpful.