### PR TITLE
storage: don't use `/dev/vda`

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -390,7 +390,7 @@ variant: fcos
 version: {butane-latest-stable-spec}
 storage:
   disks:
-    - device: /dev/vda
+    - device: /dev/disk/by-id/coreos-boot-disk
       partitions:
         - label: root
           number: 4


### PR DESCRIPTION
We have `/dev/disk/by-id/coreos-boot-disk` now which is just better. That symlink is already explained higher up on the same page, so no need to explain it again.