### PR TITLE
Wi-Fi: auto-start connection

### DIFF
--- a/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
+++ b/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
@@ -58,6 +58,7 @@ systemd:
         RemainAfterExit=yes
         ExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive NetworkManager-wifi iwlwifi-dvm-firmware
         ExecStart=/bin/touch /var/lib/%N.stamp
+        ExecStartPost=/usr/bin/systemctl restart NetworkManager.service
         [Install]
         WantedBy=multi-user.target
 storage:


### PR DESCRIPTION
Adding the NetworkManager-wifi package as an extension does not automatically start the Wi-Fi connection. NetworkManager.service should be restarted to establish the connection.