### PR TITLE
revert to using reboot for package layering examples

### DIFF
--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -7,7 +7,7 @@ However, in some cases it is necessary to add software to the base OS itself. Fo
 To do this, you can use https://coreos.github.io/rpm-ostree/[`rpm-ostree install`]. Consider these packages as "extensions": they extend the functionality of the base OS rather than e.g. providing runtimes for user applications. That said, there are no restrictions on which packages one can actually install. By default, packages are downloaded from the https://docs.fedoraproject.org/en-US/quick-docs/repositories/[Fedora repositories].
 
 To start the layering of a package, you need to write a systemd unit that executes the `rpm-ostree` command to install the wanted package(s).
-By default, with `rpm-ostree install`, changes are queued for the next boot. The `-A/--apply-live` option can be used to apply changes live *and* have them persist.
+Changes are applied to a new deployment and a reboot is necessary for those to take effect.
 
 == Example: Layering vim and setting it as the default editor
 
@@ -43,8 +43,9 @@ systemd:
         # if the package is already installed. This is useful if the package is
         # added to the root image in a future Fedora CoreOS release as it will
         # prevent the service from failing.
-        ExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive vim
+        ExecStart=/usr/bin/rpm-ostree install --allow-inactive vim
         ExecStart=/bin/touch /var/lib/%N.stamp
+        ExecStart=/bin/systemctl --no-block reboot
 
         [Install]
         WantedBy=multi-user.target

--- a/modules/ROOT/pages/os-extensions.adoc
+++ b/modules/ROOT/pages/os-extensions.adoc
@@ -43,7 +43,7 @@ systemd:
         # if the package is already installed. This is useful if the package is
         # added to the root image in a future Fedora CoreOS release as it will
         # prevent the service from failing.
-        ExecStart=/usr/bin/rpm-ostree install --allow-inactive vim
+        ExecStart=/usr/bin/rpm-ostree install -y --allow-inactive vim
         ExecStart=/bin/touch /var/lib/%N.stamp
         ExecStart=/bin/systemctl --no-block reboot
 

--- a/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
+++ b/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
@@ -56,8 +56,9 @@ systemd:
         [Service]
         Type=oneshot
         RemainAfterExit=yes
-        ExecStart=/usr/bin/rpm-ostree install --apply-live --allow-inactive NetworkManager-wifi iwlwifi-dvm-firmware
+        ExecStart=/usr/bin/rpm-ostree install --allow-inactive NetworkManager-wifi iwlwifi-dvm-firmware
         ExecStart=/bin/touch /var/lib/%N.stamp
+        ExecStart=/bin/systemctl --no-block reboot
         [Install]
         WantedBy=multi-user.target
 storage:

--- a/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
+++ b/modules/ROOT/pages/sysconfig-enabling-wifi.adoc
@@ -56,7 +56,7 @@ systemd:
         [Service]
         Type=oneshot
         RemainAfterExit=yes
-        ExecStart=/usr/bin/rpm-ostree install --allow-inactive NetworkManager-wifi iwlwifi-dvm-firmware
+        ExecStart=/usr/bin/rpm-ostree install -y --allow-inactive NetworkManager-wifi iwlwifi-dvm-firmware
         ExecStart=/bin/touch /var/lib/%N.stamp
         ExecStart=/bin/systemctl --no-block reboot
         [Install]


### PR DESCRIPTION
There is a bug that causes nodes started with --apply-live
to not be able to update via zincati [1]. We can add it back
once the bug is taken care of.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1691


---

also a second commit in there to add `-y` to the `rpm-ostree install` operations. 