### PR TITLE
provisioning/gcp: add line breaks and ZONE info

### DIFF
--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -30,7 +30,8 @@ You can inspect the current state of an image family as follows:
 [source, bash]
 ----
 STREAM='stable'
-gcloud compute images describe-from-family --project "fedora-coreos-cloud" "fedora-coreos-${STREAM}"
+gcloud compute images describe-from-family \
+    --project "fedora-coreos-cloud" "fedora-coreos-${STREAM}"
 ----
 
 == Launching a VM instance
@@ -45,8 +46,12 @@ NOTE: Currently, we don't support logging in using SSH through the GCP web conso
 [source, bash]
 ----
 STREAM='stable'
-VM_NAME='fcos-node01'
-gcloud compute instances create --image-project "fedora-coreos-cloud" --image-family "fedora-coreos-${STREAM}" "${VM_NAME}"
+NAME='fcos-node01'
+ZONE='us-central-1a'
+gcloud compute instances create              \
+    --image-project "fedora-coreos-cloud"    \
+    --image-family "fedora-coreos-${STREAM}" \
+    --zone "${ZONE} "${NAME}"
 ----
 
 TIP: You can find out the instance's assigned IP by running `gcloud compute instances list`
@@ -68,9 +73,14 @@ From the command-line, use `--metadata-from-file`:
 [source, bash]
 ----
 STREAM='stable'
-VM_NAME='fcos-node01'
+NAME='fcos-node01'
+ZONE='us-central-1a'
 CONFIG='example.ign'
-gcloud compute instances create --metadata-from-file "user-data=${CONFIG}" --image-project "fedora-coreos-cloud" --image-family "fedora-coreos-${STREAM}" "${VM_NAME}"
+gcloud compute instances create                \
+    --image-project "fedora-coreos-cloud"      \
+    --image-family "fedora-coreos-${STREAM}"   \
+    --metadata-from-file "user-data=${CONFIG}" \
+    --zone "${ZONE} "${NAME}"
 ----
 
 NOTE: By design, https://cloud.google.com/compute/docs/startupscript[startup scripts] are not supported on FCOS. Instead, it is recommended to encode any startup logic as systemd service units in the Ignition configuration.


### PR DESCRIPTION
The line breaks make it nicer to be able to view the full commands without scrolling. Adding ZONE= info here prevents an interactive question being asked on the `gcloud` CLI when starting an instance.