### PR TITLE
system configuration/wireguard: suggest using NetworkManager

### DIFF
--- a/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
@@ -1,6 +1,5 @@
 = Configuring FCOS to use WireGuard
 
-WARNING: Some examples in this page may not work properly. An issue with WireGuard SELinux isolation breaks Pre/Post actions in the WireGuard configuration for recent releases of Fedora Coreos. You can check the progress of this issue on the https://github.com/coreos/fedora-coreos-tracker/issues/1487[issue tracker]. 
 
 == Introduction
 
@@ -12,10 +11,15 @@ https://www.wireguard.com/[WireGuard] is a novel VPN that runs inside the Linux 
 
 FCOS has full support for WireGuard out of the box. This guide is going to demonstrate how to set up a single connection between a FCOS server and one client computer. It goes over the basic client configuration, but it does not cover installing WireGuard on your clients.
 
+There are several ways to set up wireguard on linux, here we suggest importing the wireguard configuration in NetworkManager.
+Another popular approach is to use [wg-quick](https://www.man7.org/linux/man-pages/man8/wg-quick.8.html) (also included in fcos but have had [SELinux isues](https://github.com/coreos/fedora-coreos-tracker/issues/1487))
+
+
 == Generate Keys
 
-You will need to generate some keys to configure WireGuard. For this guide, the keys should be pre-generated on your workstation. First, let's create the FCOS WireGuard keys:
+You will need to generate some keys to configure WireGuard. You can generate the keys on your workstation or a running FCOS system.
 
+First, let's create the FCOS WireGuard keys:
 .Generate FCOS WireGuard keys
 [source,bash]
 ----
@@ -36,7 +40,7 @@ $ wg genkey | tee privatekey | wg pubkey > publickey
 
 These keys will be referenced as `client_one_public_key` and `client_one_private_key` from here on out in this guide.
 
-Now create a PresharedKey:
+You can optionnaly generate a pre-shared key to increase security:
 
 .Generate a Preshared key per peer pair
 [source,bash]
@@ -71,19 +75,32 @@ storage:
           [Peer]
           PublicKey = <client_one_public_key>
           PresharedKey = <fcos_client_one_psk>
-          AllowedIPs = 192.168.71.0/24,fdc9:3c6b:21c7:e6bd::/64
+          AllowedIPs = 192.168.71.2/32,fdc9:3c6b:21c7:e6bd::2/128
 systemd:
   units:
-    - name: wg-quick@wg0.service
+    - name: import-wireguard-config.service
       enabled: true
+      contents: |
+        [Unit]
+        ConditionPathExists=!/etc/NetworkManager/system-connections/wg0.nmconnection
+        Description=Import wireguard configuration to NetworkManager
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=nmcli connection import type wireguard file /etc/wireguard/wg0.conf
+        [Install]
+        WantedBy=multi-user.target
 ----
+
+Note that we setup a oneshot unit to import the configuration in NetworkManager.
+
 
 Boot FCOS and log in. When you run `sudo wg show` you should see this:
 
 .Check WireGuard configuration on FCOS
 [source,bash]
 ----
-[core@wireguard-demo ~]$ sudo wg show
+[root@wireguard-demo ~]# wg show
 interface: wg0
   public key: <fcos_public_key>
   private key: (hidden)
@@ -103,7 +120,15 @@ peer: <client_one_public_key>
        valid_lft forever preferred_lft forever
 ----
 
-NOTE: <Client IP address> above is the IP or FQDN of the Client computer.
+
+NOTE: If you need to make further changes to update wireguard configuration, simply delete the connection then re-import the updated file.
+.Re-import updated Wireguard configuration on FCOS
+[source,bash]
+----
+[core@wireguard-demo ~]$ sudo nmcli con delete wg0 && sudo nmcli con import type wireguard file /etc/wireguard/wg0.conf
+Connection 'wg0' (1e4f869e-f95c-4221-b2b9-99726ffde92b) successfully deleted.
+Connection 'wg0' (18cd8e61-1cc2-43a2-9f2e-467b75cd99da) successfully added.
+----
 
 == Configure WireGuard on a client
 
@@ -126,7 +151,8 @@ AllowedIPs = 192.168.71.0/24,fdc9:3c6b:21c7:e6bd::/64
 
 NOTE: <FCOS IP address> is the IP or FQDN of the FCOS server.
 
-Write the above config to `/etc/wireguard/wg0.conf` and `chmod 0600 /etc/wireguard/wg0.conf` on your client. Run `sudo systemctl start wg-quick@wg0.service` and then check your configuration:
+Write the above config to `/etc/wireguard/wg0.conf` and `chmod 0600 /etc/wireguard/wg0.conf` on your client.
+Run `nmcli con import type wireguard file /etc/wireguard/wg0.conf` and then check your configuration:
 
 .Check WireGuard configuration on a client
 [source,bash]
@@ -141,6 +167,7 @@ peer: <fcos_public_key>
   preshared key: (hidden)
   endpoint: <FCOS IP address>:51820
   allowed ips: 192.168.71.0/24, fdc9:3c6b:21c7:e6bd::/64
+
 [root@wireguard-client ~]# ip a s wg0
 21: wg0: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1420 qdisc noqueue state UNKNOWN group default qlen 1000
     link/none
@@ -189,7 +216,6 @@ interface: wg0
   public key: <client_one_public_key>
   private key: (hidden)
   listening port: 51821
-
 peer: <fcos_public_key>
   preshared key: (hidden)
   endpoint: <Client IP address>:51820
@@ -239,8 +265,18 @@ storage:
           AllowedIPs = 192.168.71.0/24,fdc9:3c6b:21c7:e6bd::/64
 systemd:
   units:
-    - name: wg-quick@wg0.service
+    - name: import-wireguard-config.service
       enabled: true
+      contents: |
+        [Unit]
+        ConditionPathExists=!/etc/NetworkManager/system-connections/wg0.nmconnection
+        Description=Import wireguard configuration to NetworkManager
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=nmcli connection import type wireguard file /etc/wireguard/wg0.conf
+        [Install]
+        WantedBy=multi-user.target
 ----
 
 NOTE: FCOS uses https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/[predictable interface names] by https://lists.fedoraproject.org/archives/list/coreos-status@lists.fedoraproject.org/thread/6IPTZL57Z5NLBMPYMXNVSYAGLRFZBLIP/[default]. Please take care to use the correct interface name for your hardware in the above PostUp and PostDown commands!


### PR DESCRIPTION
Show how to set up wireguard with networkManager on FCOS. The wg-quick approach had selinux issues for a while now.

https://github.com/coreos/fedora-coreos-tracker/issues/1487#issuecomment-1754894320 prompted this update.