### PR TITLE
index: change welcome image to fedoracoreos-logo.svg

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Fedora CoreOS Documentation
 
-image::welcomefedoracoreos.jpg[]
+image::fedoracoreos-logo.svg[]
 
 Fedora CoreOS is an automatically updating, minimal, monolithic, container-focused operating system, designed for clusters but also operable standalone, optimized for Kubernetes but also great without it.
 Its goal is to provide the best container host to run containerized workloads securely and at scale.


### PR DESCRIPTION
The official logo, `fedoracoreos-logo.svg`, is visually to be displayed as the welcome image to the docs.

The old image, `welcomefedoracoreos.jpg`, looks like a gravestone.

---

Every single time that I visit the index of Fedora CoreOS Documentation I see a gravestone:
![image](https://github.com/user-attachments/assets/1363664e-0dd7-4c98-84dd-4c3c3bcf8672)

Please, consider changing this _welcome ~gravestone~ image_ with the official logo. Thanks