### PR TITLE
composefs: remove the kdump known issue section

### DIFF
--- a/modules/ROOT/pages/composefs.adoc
+++ b/modules/ROOT/pages/composefs.adoc
@@ -11,15 +11,6 @@ The main visible change will be that the root filesystem (/) is now small and fu
 
 == Known issues
 
-=== Kdump
-
-Right now, this prevents kdump from generating its initramfs as it gets confused by the read-only filesystem.
-If you want to use kdump and export kernels dumps to the local machine, composefs must be disabled.
-A workaround is to configure kdump with a remote target such as ssh or nfs.
-The kdump upstream developers are working on a fix. We will update this page when the workaround is no longer needed.
-
-See https://github.com/rhkdump/kdump-utils/pull/28[rhkdump/kdump-utils#28].
-
 === Top-level directories
 
 Another consequence is that it is now impossible to create top-level directories in `/`.


### PR DESCRIPTION
This issue was solved with  kdump-utils-1.0.47-1.fc41
see  https://github.com/coreos/fedora-coreos-tracker/issues/1791