### PR TITLE
cgroups v1: Remove deprecated example & add major changes section

### DIFF
--- a/modules/ROOT/pages/kernel-args.adoc
+++ b/modules/ROOT/pages/kernel-args.adoc
@@ -4,19 +4,6 @@
 
 You can specify kernel arguments in a Butane config using the `kernel_arguments` section.
 
-=== Example: Staying on cgroups v1
-
-Starting from June 2021, cgroups v2 is the default on new installations of Fedora CoreOS. Here's an example `kernelArguments` section which adds the `systemd.unified_cgroup_hierarchy=0` kernel argument so that the machine keeps using cgroups v1:
-
-[source,yaml,subs="attributes"]
-----
-variant: fcos
-version: {butane-latest-stable-spec}
-kernel_arguments:
-  should_exist:
-    - systemd.unified_cgroup_hierarchy=0
-----
-
 === Example: Disabling all CPU vulnerability mitigations
 
 Here's an example `kernelArguments` section which switches `mitigations=auto,nosmt` to `mitigations=off` to disable all CPU vulnerability mitigations:

--- a/modules/ROOT/pages/major-changes.adoc
+++ b/modules/ROOT/pages/major-changes.adoc
@@ -9,6 +9,37 @@ This list is in reverse chronological order to keep recent changes at the top.
 
 // To add a new change here, see the template at the end of the file.
 
+== cgroups v1 support disabled
+
+In systemd v256, cgroups v1 support was disabled.
+If you’ve opted out of the cgroups v2 migration in the past, your system will fail to boot after upgrading.
+You must update your kernel arguments before the update.
+
+.Update an existing system from cgroupsv1 to cgroupsv2 and immediately reboot
+
+[source,bash]
+----
+$ sudo rpm-ostree kargs --delete=systemd.unified_cgroup_hierarchy --reboot
+----
+
+=== Planning
+
+This change has been rolled out as part of the rebase to Fedora 41.
+
+|===
+|Update Stream |Targeted release date
+
+|`next` | 41.20240916.1.0 (Sep 16, 2024)
+|`testing`| 41.20241027.2.0 (Oct 28, 2024)
+|`stable`| 41.20241027.3.0 (Nov 08, 2024)
+|===
+
+=== Notes
+
+See: https://github.com/coreos/fedora-coreos-tracker/issues/1715#issuecomment-2331986149[fedora-coreos-tracker/issues#1715].
+
+Detailed description of the change, the impacts, how to test, what manual actions are needed, etc.
+
 == Podman v5.0
 
 The Podman container runtime will be upgraded from v4 to v5. This is a https://blog.podman.io/2024/03/podman-5-0-has-been-released/[major release] that removes support for CNI networking in favor of Netavark.

--- a/modules/ROOT/pages/major-changes.adoc
+++ b/modules/ROOT/pages/major-changes.adoc
@@ -53,9 +53,9 @@ This change will be rolled out together with the rebase to Fedora 40.
 |===
 |Update Stream |Targeted release date
 
-|`next` | 40.20240322.1.0
-|`testing`| To Be Determined
-|`stable`| Will follow `testing` as usual
+|`next` | 40.20240322.1.0 (Mar 24, 2024)
+|`testing`| 40.20240416.2.0 (Apr 22, 2024)
+|`stable`| 40.20240416.3.1 (May 07, 2024)
 |===
 
 === Notes


### PR DESCRIPTION
kernel-args: Remove deprecated cgroups v1 example

---

major-changes: Add a section for disabled cgroups v1

---

major-changes: Update some older release & dates

---

See: https://github.com/coreos/fedora-coreos-tracker/issues/1833