### PR TITLE
Toolbx: Remove references to a version

### DIFF
--- a/modules/ROOT/pages/debugging-with-toolbox.adoc
+++ b/modules/ROOT/pages/debugging-with-toolbox.adoc
@@ -1,52 +1,42 @@
 = Debugging with Toolbx
 
-The FCOS image is kept minimal by design to reduce the image size and the
-attack surface. This means that it does not include every troubleshooting tools
-that a normal OS may include. Instead, the recommended approach is to leverage
-containers with the https://containertoolbx.org/[toolbox] utility
-included in the image.
+The FCOS image is kept minimal by design to reduce the image size and the attack surface.
+This means that it does not include every troubleshooting tools that a normal OS may include.
+Instead, the recommended approach is to leverage containers with the https://containertoolbx.org/[toolbox] utility included in the image.
 
 == What is Toolbx?
 
-Toolbx is a utility that allows you to create privileged containers meant to
-debug and troubleshoot your instance. It is a wrapper around podman which
-starts long running containers with default mounts and namespaces to facilitate
-debugging the host system.
+Toolbx is a utility that allows you to create privileged containers meant to debug and troubleshoot your instance.
+It is a wrapper around podman which starts long running containers with default mounts and namespaces to facilitate debugging the host system.
 
-These containers can then be used to install tools that you may need for
-troubleshooting.
+These containers can then be used to install tools that you may need for troubleshooting.
 
 == Using Toolbx
 
-You can create a new toolbox by running the command below. On the first run,
-this will ask you if you want to use the image
-`registry.fedoraproject.org/fedora-toolbox:35`.
+You can create a new toolbox by running the command below.
 
 [source,sh]
 ----
-toolbox create
+toolbox create my_toolbox
 ----
 
-You can then list all the running toolboxes running on the host. This should
-show you your newly created toolbox. In this case, it is named
-`fedora-toolbox-35`.
+You can then list all the running toolboxes running on the host.
+This should show you your newly created toolbox. In this case, it is named `my_toolbox`.
 
 [source,sh]
 ----
 toolbox list
 ----
 
-As pointed out by the output of the `toolbox create` command, you can enter the
-following command to enter your toolbox.
+As pointed out by the output of the `toolbox create my_toolbox` command, you can enter the following command to enter your toolbox.
 
 [source,sh]
 ----
-toolbox enter
+toolbox enter my_toolbox
 ----
 
-Now that you're in the container, you can use the included `dnf` package
-manager to install packages. For example, let's install `strace` to look at
-read syscall done by the host's `toolbox` utility.
+Now that you're in the container, you can use the included `dnf` package manager to install packages.
+For example, let's install `strace` to look at read syscall done by the host's `toolbox` utility.
 
 [source,sh]
 ----
@@ -55,14 +45,12 @@ sudo dnf install strace
 strace -eread /run/host/usr/bin/toolbox list
 ----
 
-Once done with your container, you can exit the container and then remove it
-from the host with the following command.
+Once done with your container, you can exit the container and then remove it from the host with the following command.
 
 [source,sh]
 ----
-toolbox rm --force fedora-toolbox-35
+toolbox rm --force my_toolbox
 ----
 
-NOTE: Toolbx allows you to create toolboxes with your custom
-images. You can find more details in the
-https://github.com/containers/toolbox/tree/main/doc[toolbox manpages].
+NOTE: Toolbx allows you to create toolboxes with your custom images.
+You can find more details in the https://github.com/containers/toolbox/tree/main/doc[toolbox manpages].

--- a/modules/ROOT/pages/debugging-with-toolbox.adoc
+++ b/modules/ROOT/pages/debugging-with-toolbox.adoc
@@ -1,7 +1,7 @@
 = Debugging with Toolbx
 
 The FCOS image is kept minimal by design to reduce the image size and the attack surface.
-This means that it does not include every troubleshooting tools that a normal OS may include.
+This means that it does not include every troubleshooting tool that a normal OS may include.
 Instead, the recommended approach is to leverage containers with the https://containertoolbx.org/[toolbox] utility included in the image.
 
 == What is Toolbx?
@@ -13,7 +13,7 @@ These containers can then be used to install tools that you may need for trouble
 
 == Using Toolbx
 
-You can create a new toolbox by running the command below.
+You can create a new toolbox by running the command below. On the first run it will ask you if you want to download an image. Answer yes with `y`. 
 
 [source,sh]
 ----


### PR DESCRIPTION
Remove references to a toolbox version (i.e. 35)
so it doesn't need to be updated for each release.

Improve AsciiDoc syntax.

This change was discussed during the
preparatory video session for the F42 test day.