### PR TITLE
Fix typo in update-streams.adoc

### DIFF
--- a/modules/ROOT/pages/update-streams.adoc
+++ b/modules/ROOT/pages/update-streams.adoc
@@ -56,7 +56,7 @@ sudo systemctl stop zincati.service
 # Supported architectures: aarch64, ppc64le, s390x, x86_64
 # Available streams: "stable", "testing", and "next"
 STREAM="testing"
-sudo rpm-ostree rebase "ostree-remote-registry:fedora://quay.io/fedora/fedora-coreos:${STREAM}"
+sudo rpm-ostree rebase "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:${STREAM}"
 ----
 
 After inspecting the package difference the user can reboot. After boot the system will be loaded into the latest release on the new stream and will follow that stream for future updates.


### PR DESCRIPTION
Following the instructions in `update-streams.adoc`, on an FCOS 41 `stable` machine, attempting to try `testing` (which now tracks FCOS 42), I received the following error:
```
$ sudo rpm-ostree rebase "ostree-remote-registry:fedora://quay.io/fedora/fedora-coreos:testing"
Pulling manifest: ostree-remote-image:fedora:docker:////quay.io/fedora/fedora-coreos:testing
error: Creating importer: failed to invoke method OpenImage: failed to invoke method OpenImage: invalid reference format
```

Removing the `//` after `fedora:`, the command succeeded
```
$ sudo rpm-ostree rebase "ostree-remote-registry:fedora:quay.io/fedora/fedora-coreos:testing"
Pulling manifest: ostree-remote-image:fedora:docker://quay.io/fedora/fedora-coreos:testing
Importing: ostree-remote-image:fedora:docker://quay.io/fedora/fedora-coreos:testing (digest: sha256:a1f799fd9644c08256db983cc641fb7d4fdef1dc9194e47fa5daf85cb7f485e8)
```

Presuming this is a typo in the documentation and not a bug in `rpm-ostree` itself, this PR should resolve things.