### PR TITLE
Fix iPXE kernel URL

### DIFF
--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -89,7 +89,7 @@ set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/$\{STREAM}/builds/$\{VERSION}/x86_64
 
-kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img coreos.inst.install_dev=$\{INSTALLDEV} coreos.inst.ignition_url=$\{CONFIGURL}
+kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel.x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img coreos.inst.install_dev=$\{INSTALLDEV} coreos.inst.ignition_url=$\{CONFIGURL}
 initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.img
 
 boot


### PR DESCRIPTION
According to [official downloads page](https://fedoraproject.org/coreos/download), kernel URL is actually wrong.

This PR fixes the typo.