### PR TITLE
Add Proxmox to nav and platforms

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -18,6 +18,7 @@
 ** xref:provisioning-openstack.adoc[Booting on OpenStack]
 ** xref:provisioning-oraclecloud.adoc[Booting on Oracle Cloud]
 ** xref:provisioning-nutanix.adoc[Booting on Nutanix]
+** xref:provisioning-proxmoxve.adoc[Booting on Proxmox]
 ** xref:provisioning-qemu.adoc[Booting on QEMU]
 ** xref:provisioning-raspberry-pi4.adoc[Booting on the Raspberry Pi 4]
 ** xref:provisioning-virtualbox.adoc[Booting on VirtualBox]

--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -20,6 +20,7 @@ The currently supported platforms and their identifiers are listed below.
 * Bare metal (`metal`): With BIOS, UEFI or network boot, with standard or 4k Native disks. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE].
 * Nutanix (`nutanix`): Hypervisor.
 * OpenStack (`openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
+* Proxmox (`proxmoxve`): Hypervisor. See xref:provisioning-proxmoxve.adoc[Booting on Proxmox]
 * QEMU (`qemu`): Hypervisor. See xref:provisioning-libvirt.adoc[Booting on libvirt]
 * VirtualBox (`virtualbox`): Hypervisor. See xref:provisioning-virtualbox.adoc[Booting on VirtualBox].
 * VMware ESXi, Fusion, and Workstation (`vmware`): Hypervisor. See xref:provisioning-vmware.adoc[Booting on VMware]. Fedora CoreOS images currently use https://kb.vmware.com/s/article/1003746[hardware version] 17, supporting VMware ESXi 7.0 or later, Fusion 12.0 or later, and Workstation 16.0 or later.


### PR DESCRIPTION
This pull request adds a new entry to the navigation file and platform list file to include a reference for docs on provisioning CoreOS on Proxmox VE.

Apparently this was missed by #742.