### PR TITLE
update-streams: fix command to use ${STREAM}

### DIFF
--- a/modules/ROOT/pages/update-streams.adoc
+++ b/modules/ROOT/pages/update-streams.adoc
@@ -62,7 +62,7 @@ sudo rpm-ostree rebase "ostree-remote-registry:fedora:quay.io/fedora/fedora-core
 ====
 We are currently in a https://github.com/coreos/fedora-coreos-tracker/issues/2029[transition period].
 When switching to the `next` stream you'll need to
-use `sudo rpm-ostree rebase "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:{stream}"`
+use `sudo rpm-ostree rebase "ostree-image-signed:docker://quay.io/fedora/fedora-coreos:${STREAM}"`
 in the above instructions.
 ====
 


### PR DESCRIPTION
The variable has upper case letters and also needs the `$`.

Fixes 255ac10