### PR TITLE
Fix kernel filename in live-booting.adoc

### DIFF
--- a/modules/ROOT/pages/live-booting.adoc
+++ b/modules/ROOT/pages/live-booting.adoc
@@ -60,7 +60,7 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL fedora-coreos-{stable-version}-live-kernel-x86_64
+    KERNEL fedora-coreos-{stable-version}-live-kernel.x86_64
     APPEND initrd=fedora-coreos-{stable-version}-live-initramfs.x86_64.img,fedora-coreos-{stable-version}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=http://192.168.1.101/config.ign
 IPAPPEND 2
 ----
@@ -81,7 +81,7 @@ set CONFIGURL https://example.com/config.ign
 
 set BASEURL https://builds.coreos.fedoraproject.org/prod/streams/$\{STREAM}/builds/$\{VERSION}/x86_64
 
-kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel-x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=$\{CONFIGURL}
+kernel $\{BASEURL}/fedora-coreos-$\{VERSION}-live-kernel.x86_64 initrd=main coreos.live.rootfs_url=$\{BASEURL}/fedora-coreos-$\{VERSION}-live-rootfs.x86_64.img ignition.firstboot ignition.platform.id=metal ignition.config.url=$\{CONFIGURL}
 initrd --name main $\{BASEURL}/fedora-coreos-$\{VERSION}-live-initramfs.x86_64.img
 
 boot


### PR DESCRIPTION
The kernel file is missing a dot and could cause confusion for first-time or distracted users.