### PR TITLE
fix(provisioning-kubevirt.adoc): duplicate name field in devices spec template

### DIFF
--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -131,7 +131,6 @@ spec:
           - name: cloudinitdisk
             disk:
               bus: virtio
-            name: cloudinitdisk
           rng: {}
         resources:
           requests:


### PR DESCRIPTION
Signed-off-by: Jennifer Weir <contact@jenniferpweir.com>

Fixes error that occurs when yaml is applied for virtual machine with persistent storage
```bash
error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 32: mapping key "name" already defined at line 29
```