### PR TITLE
bootloader-updates: automatic updates for the bootloader are enabled by default

### DIFF
--- a/modules/ROOT/pages/bootloader-updates.adoc
+++ b/modules/ROOT/pages/bootloader-updates.adoc
@@ -2,8 +2,8 @@
 
 == bootupd
 
-Updating the bootloader is not currently automatic. The https://github.com/coreos/bootupd/[bootupd]
-project is included in Fedora CoreOS and may be used for manual updates.
+The bootloader update is now performed automatically by default. The https://github.com/coreos/bootupd/[bootupd]
+project is included in Fedora CoreOS and supports both manual and automatic updates.
 
 This is usually only relevant on bare metal scenarios, or virtualized
 hypervisors that support Secure Boot. An example reason to update the
@@ -19,7 +19,6 @@ Inspect the system status:
 Component EFI
   Installed: grub2-efi-x64-1:2.04-31.fc33.x86_64,shim-x64-15-8.x86_64
   Update: At latest version
-#
 ----
 
 If an update is available, use `bootupctl update` to apply it; the
@@ -30,18 +29,6 @@ change will take effect for the next reboot.
 # bootupctl update
 ...
 Updated: grub2-efi-x64-1:2.04-31.fc33.x86_64,shim-x64-15-8.x86_64
-#
-----
-
-.Example enable bootloader-update.service to automate bootupd updates
-[source,yaml,subs="attributes"]
-----
-variant: fcos
-version: {butane-latest-stable-spec}
-systemd:
-  units:
-    - name: bootloader-update.service
-      enabled: true
 ----
 
 === Using images that predate bootupd
@@ -55,10 +42,4 @@ is `Adoptable`, perform the adoption with `bootupctl adopt-and-update`.
 # bootupctl adopt-and-update
 ...
 Updated: grub2-efi-x64-1:2.04-31.fc33.x86_64,shim-x64-15-8.x86_64
-#
 ----
-
-=== Future versions may default to automatic updates
-
-It is possible that future Fedora CoreOS versions may default
-to automating bootloader updates similar to the above.


### PR DESCRIPTION
Starting from F43, the `bootloader-update.service` is enabled by default.

Related commit: https://gitlab.com/fedora/bootc/base-images/-/commit/6af3341f8037c872985e5b0e8a92e9470b18ddb7