### PR TITLE
docs: Fix typos and improve clarity across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ And replaced it with a pointer to my fork:
 ...
 ```
 
-I could also point to a local repository, using `HEAD` as a branch to preview the what's changed without the need of making a commit.
+I could also point to a local repository, using `HEAD` as a branch to preview what's changed without the need of making a commit.
 
 **Note:** I would need to move the repository under the `docs-fp-o` directory, because the builder won't see anything above.
 So I would need to create a `repositories` directory in `docs-fp-o` and copy my repository into it.
@@ -120,6 +120,6 @@ To build the whole site, I would run the following in the `docs-fp-o` directory.
 ```
 $ ./docsbuilder.sh -p
 ```
-# License
+## License
 
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/modules/ROOT/pages/audit.adoc
+++ b/modules/ROOT/pages/audit.adoc
@@ -2,7 +2,7 @@
 
 Starting with the first release based on Fedora 39, Fedora CoreOS includes the audit daemon (`auditd`) to load and manage audit rules.
 
-Like all system daemons on Fedora CoreOS, the audit daemon is managed by systemd but with an exception: it can not be stopped or restarted via `systemctl stop auditd` or `systemctl restart auditd` for compliance reasons.
+Like all system daemons on Fedora CoreOS, the audit daemon is managed by systemd but with an exception: it cannot be stopped or restarted via `systemctl stop auditd` or `systemctl restart auditd` for compliance reasons.
 
 From https://access.redhat.com/solutions/2664811[Unable to restart/stop auditd service using systemctl command in RHEL]:
 

--- a/modules/ROOT/pages/bare-metal.adoc
+++ b/modules/ROOT/pages/bare-metal.adoc
@@ -123,7 +123,7 @@ To download the 4kn native metal image with `coreos-installer download`, use the
 
 NOTE: The metal image uses a hybrid partition layout which supports both BIOS and UEFI booting.
 
-When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-install --image-file <PATH>`.
+When you're finally ready to install FCOS, you can point it at your downloaded image using `coreos-installer install --image-url <LOCAL_MIRROR>` or `coreos-installer --image-file <PATH>`.
 
 == Customizing installation
 
@@ -177,7 +177,7 @@ Alternatively, instead of generating per-machine ISOs, you can have a `--pre-ins
 === Installing on iSCSI
 
 To install CoreOS on an iSCSI boot device, follow the same
-steps as described above to get the live environnement, and add the iSCSI-related kernel arguments.
+steps as described above to get the live environment, and add the iSCSI-related kernel arguments.
 
 
 - Mount the iSCSI target from the live environment:
@@ -195,32 +195,32 @@ On a completely diskless machine, the iscsi target and initiator values can be p
 These could be supplied with an iPXE boot script for example:
 
 [source, bash]
----
+----
 #!ipxe
 set initiator-iqn iqn.2023-11.coreos.diskless:testsetup
 sanboot iscsi:10.0.0.1::::iqn.2023-10.coreos.target.vm:coreos
----
+----
 
 [source, bash]
----
+----
 sudo coreos-installer install \
     /dev/disk/by-path/ip-10.0.0.1\:3260-iscsi-iqn.2023-10.coreos.target.vm\:coreos-lun-0 \
     --append-karg rd.iscsi.firmware=1 --append-karg ip=ibft \
     --console ttyS0 \
     --ignition-url https://example.com/example.ign
----
+----
 
 
 .Installing to an iSCSI target with manual configuration
 [source, bash]
----
+----
 sudo coreos-installer install \
     /dev/disk/by-path/ip-10.0.0.1\:3260-iscsi-iqn.2023-10.coreos.target.vm\:coreos-lun-0 \
     --append-karg rd.iscsi.initiator=iqn.2024-02.com.yourorg.name:lun0 \
-    --append-karg netroot=iscsi:iqn.2023-10.coreos.target.vm:coreos` \
+    --append-karg netroot=iscsi:iqn.2023-10.coreos.target.vm:coreos \
     --console ttyS0 \
     --ignition-url https://example.com/example.ign
----
+----
 
 
 All this can also be set using `coreos-installer iso customize` or `coreos-installer pxe customize`. (See "Customizing installation" section above).

--- a/modules/ROOT/pages/composefs.adoc
+++ b/modules/ROOT/pages/composefs.adoc
@@ -1,8 +1,8 @@
 = Composefs
 
 Fedora CoreOS introduced composefs enabled by default starting in Fedora 41.
-Composefs is an overlay filesystem where the data comes from the usual ostree deployement, and metadata are in the composefs file.
-The result is a truely read-only root (`/`) filesystem, increasing the system integrity and robustness.
+Composefs is an overlay filesystem where the data comes from the usual ostree deployment, and metadata is in the composefs file.
+The result is a truly read-only root (`/`) filesystem, increasing the system integrity and robustness.
 
 This is a first step towards a full verification of filesystem integrity, even at runtime.
 
@@ -23,7 +23,7 @@ Currently, the only way around that is to disable composefs as shown below.
 
 Composefs can be disabled through a kernel argument: `ostree.prepare-root.composefs=0`.
 
-.Disabling composefs at provisionning
+.Disabling composefs at provisioning
 [source,yaml,subs="attributes"]
 ----
 variant: fcos

--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -42,7 +42,7 @@ storage:
 == Networking in the Initramfs via Kernel Arguments
 If networking in the initramfs is required, the kernel argument `ifname=` will dynamically create a udev rule to change the name of a NIC.
 
-Currently, unlike other parts of the networking config from the initramfs (e.g. static IPs, hostnames, etc.), these udev rules are not persisted into the real root. If the custom name needs to be applied to the real root, either a link file or udev rule must be created, as shown above. See xref:https://github.com/coreos/fedora-coreos-tracker/issues/553[this issue] for more details.
+Currently, unlike other parts of the networking config from the initramfs (e.g. static IPs, hostnames, etc.), these udev rules are not persisted into the real root. If the custom name needs to be applied to the real root, either a link file or udev rule must be created, as shown above. See https://github.com/coreos/fedora-coreos-tracker/issues/553[this issue] for more details.
 
 For example, to give the NIC with the MAC address `12:34:56:78:9a:bc` a name of "infra", provide a `ifname=infra:12:34:56:78:9a:bc` kernel argument. A udev rule would be created in the initramfs like:
 [source]

--- a/modules/ROOT/pages/docker-ce.adoc
+++ b/modules/ROOT/pages/docker-ce.adoc
@@ -10,7 +10,7 @@ You can then install and update Docker CE from this repository.
 
 == Installing Docker CE on first boot
 
-On provisioning, you can install Docker CE during the first boot of the system via ignition configuration.
+On provisioning, you can install Docker CE during the first boot of the system via Ignition configuration.
 
 .Example Butane config for setting up Docker CE
 [source,yaml,subs="attributes"]

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,6 +1,6 @@
 = Fedora CoreOS Frequently Asked Questions
 
-If you have other questions than are mentioned here or want to discuss
+If you have questions other than those mentioned here or want to discuss
 further, join us in our Matrix room,
 link:https://chat.fedoraproject.org/#/room/#coreos:fedoraproject.org[#coreos:fedoraproject.org],
 or on our https://discussion.fedoraproject.org/tag/coreos[discussion board].
@@ -110,7 +110,7 @@ For more about this, please refer to xref:running-containers.adoc[documentation]
 
 == Where is my preferred tool for troubleshooting?
 
-The FCOS image is kept minimal by design. Not every troubleshooting tool are
+The FCOS image is kept minimal by design. Not every troubleshooting tool is
 included by default. Instead, it is recommended to use the `toolbox` utility.
 
 xref:debugging-with-toolbox.adoc[Debugging with Toolbx].
@@ -320,7 +320,7 @@ If your system is in this state you have two options:
 
 == Why is the `systemd-repart.service` systemd unit masked?
 
-https://www.freedesktop.org/software/systemd/man/systemd-repart.html[system-repart]
+https://www.freedesktop.org/software/systemd/man/systemd-repart.html[systemd-repart]
 is a tool to grow and add partitions to a partition table. On Fedora CoreOS, we
 only support using Ignition to create partitions, filesystems and mount points,
 thus systemd-repart is masked by default.
@@ -336,7 +336,7 @@ entry for an example config to unmask this unit.
 [#wifi-fw]
 == How do I keep dropped wireless firmware?
 
-Some Wi-Fi firmwares were split into subpackages in Fedora 39 and Fedora 40. Fedora CoresOS will keep them in until Fedora 41, but display a warning message in the console if `NetworkManager-wifi` is layered without any other Wi-Fi firmware packages layered.
+Some Wi-Fi firmwares were split into subpackages in Fedora 39 and Fedora 40. Fedora CoreOS will keep them in until Fedora 41, but display a warning message in the console if `NetworkManager-wifi` is layered without any other Wi-Fi firmware packages layered.
 
 To request the Wi-Fi firmware stay installed even when Fedora CoreOS drops these packages please follow the xref:sysconfig-enabling-wifi.adoc#_on_an_existing_fedora_coreos_system[steps to perform Wi-Fi enablement on an existing system].
 

--- a/modules/ROOT/pages/getting-started-libvirt.adoc
+++ b/modules/ROOT/pages/getting-started-libvirt.adoc
@@ -41,7 +41,7 @@ virt-install --connect="qemu:///system" --name="${VM_NAME}" --vcpus="${VCPUS}" -
 
 NOTE: `virt-install` requires both the OS image and Ignition file to be specified as absolute paths.
 
-NOTE: Depending on your version of `virt-install`, you may not be able to use `--os-variant=fedora-coreos-*` and will get an error. In this case, you should pick an older Fedora variant (`--os-variant=fedora31` for example). You can find the variants that are supported by you current version of `virt-install` with `osinfo-query os | grep '^\s*fedora'`.
+NOTE: Depending on your version of `virt-install`, you may not be able to use `--os-variant=fedora-coreos-*` and will get an error. In this case, you should pick an older Fedora variant (`--os-variant=fedora31` for example). You can find the variants that are supported by your current version of `virt-install` with `osinfo-query os | grep '^\s*fedora'`.
 
 NOTE: `DISK_GB` should be at least as big as the default size of the image. For Fedora CoreOS, this is currently 10 GB.
 

--- a/modules/ROOT/pages/major-changes.adoc
+++ b/modules/ROOT/pages/major-changes.adoc
@@ -33,7 +33,7 @@ After a few releases we will migrate existing machines through a barrier release
 
 Currently, Fedora CoreOS hosts pull updates from the OSTree repository.
 With this change, the hosts will pull updates from the Quay.io container registry instead.
-This should be a transparent change, altough proxied environnements require attention as the nodes will reach to a different address for updates.
+This should be a transparent change, although proxied environments require attention as the nodes will reach to a different address for updates.
 
 Note: Disk images will be updated first, so new installations of Fedora CoreOS based on Fedora 42 will use OCI images.
 After a few releases, we will migrate existing nodes.
@@ -100,7 +100,7 @@ The full release notes for Podman v5 are available https://github.com/containers
 
 - In the (unlikely) case that you were using podman machine inside of Fedora CoreOS, you will have to delete and re-create your podman machine. See https://blog.podman.io/2024/03/migration-of-podman-4-to-podman-5-machines/[Migration of Podman 4 to Podman 5 machines] for more details.
 
-- Support for cgroups v1 is deprecated and will removed in a future version.
+- Support for cgroups v1 is deprecated and will be removed in a future version.
 
 - Rollbacks to a previous version with Podman v4.x will likely require manual action.
 

--- a/modules/ROOT/pages/managing-files.adoc
+++ b/modules/ROOT/pages/managing-files.adoc
@@ -45,7 +45,7 @@ content is checked against the hash value specified in the config. The format
 is `sha512-` followed by the 128 hex characters given by the sha512sum command.
 The resulting file is made readable and executable by all.
 
-.Example to create a files from a remote source
+.Example to create a file from a remote source
 [source,yaml,subs="attributes"]
 ----
 variant: fcos

--- a/modules/ROOT/pages/manual-rollbacks.adoc
+++ b/modules/ROOT/pages/manual-rollbacks.adoc
@@ -15,7 +15,7 @@ To permanently revert to the previous OS deployment, log into the target node an
 # Stop the service that performs automatic updates
 sudo systemctl stop zincati.service
 
-# Mark the previous OS deployment as the default, and immediately reboots into it
+# Mark the previous OS deployment as the default and immediately reboot into it
 sudo rpm-ostree rollback -r
 ----
 

--- a/modules/ROOT/pages/platforms.adoc
+++ b/modules/ROOT/pages/platforms.adoc
@@ -36,14 +36,14 @@ The currently supported platforms and their identifiers are listed below.
 * Amazon Web Services (`aws`): Cloud platform. See xref:provisioning-aws.adoc[Booting on AWS].
 * Bare metal (`metal`): With UEFI or network boot, with standard or 4k Native disks. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE] and xref:provisioning-raspberry-pi4.adoc[Booting on the Raspberry Pi 4].
 * QEMU (`qemu`): Hypervisor. See xref:provisioning-libvirt.adoc[Booting on libvirt]
-* OpenStack (cloud platform): `openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
+* OpenStack (`openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
 
 === s390x
 
 * IBM Cloud (`ibmcloud`): Cloud platform. See xref:provisioning-ibmcloud.adoc[Booting on IBM Cloud].
 * Bare metal (`metal`): From disk or network boot. See xref:bare-metal.adoc[Installing on Bare Metal] or xref:live-booting-ipxe.adoc[Live-booting via iPXE].
 * QEMU (`qemu`): Hypervisor. See xref:provisioning-libvirt.adoc[Booting on libvirt]
-* OpenStack (cloud platform): `openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
+* OpenStack (`openstack`): Cloud platform. See xref:provisioning-openstack.adoc[Booting on OpenStack].
 
 == Runtime introspection of platform IDs
 

--- a/modules/ROOT/pages/producing-ign.adoc
+++ b/modules/ROOT/pages/producing-ign.adoc
@@ -203,7 +203,7 @@ passwd:
 
 TIP: YAML files must have consistent indentation. Although Butane checks for syntax errors, ensure that the indentation matches the above example. Overall, the Butane configs must conform to Butane's https://coreos.github.io/butane/specs/[configuration specification] format.
 
-TIP: If you use VScode with the https://github.com/redhat-developer/vscode-yaml[Red Hat Yaml extension] you can associate `*.bu` files to `yaml` in the `files.associations` setting and get help/auto completion.
+TIP: If you use VS Code with the https://github.com/redhat-developer/vscode-yaml[Red Hat Yaml extension] you can associate `*.bu` files to `yaml` in the `files.associations` setting and get help/auto completion.
 
 TIP: You may also set a login password for the console (password authentication over SSH is disabled). See https://docs.fedoraproject.org/en-US/fedora-coreos/authentication/#_using_password_authentication[Using Password Authentication].
 

--- a/modules/ROOT/pages/provisioning-applehv.adoc
+++ b/modules/ROOT/pages/provisioning-applehv.adoc
@@ -41,7 +41,7 @@ Vfkit is not a stateful virtual machine framework. You simply need to run the vf
 
 * 2 virtual CPUs
 * 2 GB of memory
-* a network device that will receive a IP address from Vfit
+* a network device that will receive an IP address from vfkit
 * a GUI console with keyboard and mouse support
 
 .Launching FCOS with Vfkit

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -80,7 +80,7 @@ CONFIG='/path/to/config.ign' # path to your Ignition config
 aws s3 cp $CONFIG s3://$NAME-infra/bootstrap.ign
 ----
 
-You can verify the file have been correctly uploaded:
+You can verify the file has been correctly uploaded:
 
 .List files in the bucket
 [source, bash]
@@ -183,7 +183,7 @@ NAME='instance1'
 aws s3 rm s3://$NAME-infra/bootstrap.ign
 ----
 
-Optionnally, you can delete the whole bucket:
+Optionally, you can delete the whole bucket:
 
 .Deleting the s3 bucket
 [source,bash]

--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -8,7 +8,7 @@ Before provisioning an FCOS machine, it is recommended to have an Ignition confi
 
 NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
 
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support]..
+If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
 
 You also need to have access to an Exoscale account. https://portal.exoscale.com/register[Register] if you don't have one.
 
@@ -32,7 +32,7 @@ Next you can https://community.exoscale.com/documentation/compute/custom-templat
 .Upload to Object Storage and create Custom Template
 [source, bash]
 ----
-# Set the version and calcuate the checksum
+# Set the version and calculate the checksum
 FCOS_VERSION='...'
 FILE="fedora-coreos-${FCOS_VERSION}-exoscale.x86_64.qcow2"
 CHECKSUM=$(md5sum "${FILE}" | cut -d " " -f 1)

--- a/modules/ROOT/pages/provisioning-hetzner.adoc
+++ b/modules/ROOT/pages/provisioning-hetzner.adoc
@@ -29,7 +29,7 @@ If you do not want to use Ignition to get started, you can make use of the https
 You also need to have access to a Hetzner account.
 The examples below use the https://github.com/hetznercloud/cli[hcloud] command-line tool, the https://github.com/apricote/hcloud-upload-image[hcloud-upload-image] tool and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 
-== Downloading an Hetzner image
+== Downloading a Hetzner image
 
 Fedora CoreOS is designed to be updated automatically, with different schedules per stream. Once you have picked the relevant stream, download and verify the latest Hetzner image:
 

--- a/modules/ROOT/pages/provisioning-kubevirt.adoc
+++ b/modules/ROOT/pages/provisioning-kubevirt.adoc
@@ -86,7 +86,7 @@ virtctl ssh core@my-fcos
 
 == Launching a virtual machine with persistent storage
 
-The above example will give you a VM that will lose any changes made to it if it is stopped and started again. You can instruct the cluster to import a containerdisk into a Physical Volume when provisioning in order to have virtual machine will have persistence of the OS disk across stop/start operations.
+The above example will give you a VM that will lose any changes made to it if it is stopped and started again. You can instruct the cluster to import a containerdisk into a Physical Volume when provisioning in order for the virtual machine to have persistence of the OS disk across stop/start operations.
 
 The positive to this approach is that the machine behaves much more like a traditional virtual machine. The drawback is that the cluster needs to offer Block PV storage and not all clusters may do that.
 

--- a/modules/ROOT/pages/provisioning-proxmoxve.adoc
+++ b/modules/ROOT/pages/provisioning-proxmoxve.adoc
@@ -158,7 +158,7 @@ qm start ${VM_ID}
 
 === Exploring the OS
 
-You log into the VM from the host with the following command:
+You can log into the VM from the host with the following command:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/provisioning-qemu.adoc
+++ b/modules/ROOT/pages/provisioning-qemu.adoc
@@ -14,7 +14,7 @@ TIP: If running with SELinux enabled, make sure your OS image and Ignition file 
 
 == Booting a new VM on QEMU
 
-This section shows how to boot a new VM on QEMU. Based on the platform, The Ignition file is passed to the VM, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device.
+This section shows how to boot a new VM on QEMU. Based on the platform, the Ignition file is passed to the VM, which sets the `opt/com.coreos/config` key in the QEMU firmware configuration device.
 
 You can use `-snapshot` to make `qemu-kvm` allocate temporary storage for the VM, or `qemu-img create` to first create a layered qcow2.
 

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -16,7 +16,7 @@ You also need to have access to a Vultr account. The examples below use the http
 
 Vultr supports creating custom snapshots from public raw images.
 
-These steps show how to download a FCOS image and upload it to an existing storage bucket, in order to create a snapshot from that.
+These steps show how to download an FCOS image and upload it to an existing storage bucket, in order to create a snapshot from that.
 
 See https://www.vultr.com/docs/vultr-object-storage[Vultr documentation] for further details on how to create a bucket and configure `s3cmd` to use it.
 
@@ -54,7 +54,7 @@ NOTE: You'll need to wait for the snapshot to finish processing before using it.
 
 === Launching an instance from a snapshot
 
-You can now create a FCOS Vultr instance using the snapshot ID above.
+You can now create an FCOS Vultr instance using the snapshot ID above.
 
 This example creates a 2 vCPU, 4GB RAM instance named `instance1` in the New Jersey region. Use `vultr-cli regions list` and `vultr-cli plans list` for other options.
 

--- a/modules/ROOT/pages/remote-ign.adoc
+++ b/modules/ROOT/pages/remote-ign.adoc
@@ -34,7 +34,7 @@ ignition:
 
 NOTE: The certificate authorities listed here are not automatically added to the host filesystem. They are solely used by Ignition itself when fetching over `https`. If you'd like to also install them on the host filesystem, include them as usual under the `storage.files` array.
 
-In some cases, if you need to merge a local configuration and one or several remote ones, you can use the `merge` rather than `replace` in a Butane config.
+In some cases, if you need to merge a local configuration and one or several remote ones, you can use `merge` rather than `replace` in a Butane config.
 
 .Retrieving a remote Ignition file via HTTPS and merging it with the current config
 [source,yaml,subs="attributes"]

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -306,7 +306,7 @@ storage:
 
 The expanded config doesn't include the `path` or `with_mount_unit` keys; FCOS knows that the root partition is special and will figure out how to find it and mount it.
 
-This next example binds the root filesystem encryption to PCR 7 which corresponds to the https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/[UEFI Boot Component] used to track the Secure Boot certificate from memory. Therefore, updates to the the UEFI firmware/certificates should not affect the value stored in PCR 7.
+This next example binds the root filesystem encryption to PCR 7 which corresponds to the https://uapi-group.org/specifications/specs/linux_tpm_pcr_registry/[UEFI Boot Component] used to track the Secure Boot certificate from memory. Therefore, updates to the UEFI firmware/certificates should not affect the value stored in PCR 7.
 
 NOTE: Binding for PCR 8 (UEFI Boot Component used to track commands and kernel command line) is not supported as the kernel command line changes with every OS update.
 

--- a/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
@@ -198,7 +198,7 @@ peer: <fcos_public_key>
 
 == Route all traffic over WireGuard
 
-If you plan on forwarding all of your client's traffic through the FCOS instance you will need to enable IP Forwarding and you need to set and set some PostUp and PostDown directives:
+If you plan on forwarding all of your client's traffic through the FCOS instance you will need to enable IP Forwarding and set some PostUp and PostDown directives:
 
 .Example FCOS WireGuard configuration with IP forwarding
 [source,yaml,subs="attributes"]

--- a/modules/ROOT/pages/tutorial-autologin.adoc
+++ b/modules/ROOT/pages/tutorial-autologin.adoc
@@ -32,7 +32,7 @@ systemd:
           [Service]
           # Override Execstart in main unit
           ExecStart=
-          # Add new Execstart with `-` prefix to ignore failure`
+          # Add new Execstart with `-` prefix to ignore failure
           ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
 storage:
   files:
@@ -89,7 +89,7 @@ The resulting Ignition configuration produced by Butane as `autologin.ign` has t
       {
         "dropins": [
           {
-            "contents": "[Service]\n# Override Execstart in main unit\nExecStart=\n# Add new Execstart with `-` prefix to ignore failure`\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM\n",
+            "contents": "[Service]\n# Override Execstart in main unit\nExecStart=\n# Add new Execstart with `-` prefix to ignore failure\nExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM\n",
             "name": "autologin-core.conf"
           }
         ],
@@ -161,7 +161,7 @@ Let's verify that our configuration has been correctly applied. As we were autom
 [Service]
 # Override Execstart in main unit
 ExecStart=
-# Add new Execstart with `-` prefix to ignore failure`
+# Add new Execstart with `-` prefix to ignore failure
 ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
 ----
 

--- a/modules/ROOT/pages/tutorial-containers.adoc
+++ b/modules/ROOT/pages/tutorial-containers.adoc
@@ -1,6 +1,6 @@
 = Setting up SSH access and starting containers at boot
 
-NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have create file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
+NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have created the file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
 
 In this tutorial, we will set up SSH access and start a container at boot. Fedora CoreOS is focused on running applications/services in containers thus we recommend trying to run containers and avoid modifying the host directly. Running containers and keeping a pristine host layer makes automatic updates more reliable and allows for separation of concerns with the Fedora CoreOS team responsible for the OS and end-user operators/sysadmins responsible for the applications.
 

--- a/modules/ROOT/pages/tutorial-services.adoc
+++ b/modules/ROOT/pages/tutorial-services.adoc
@@ -67,7 +67,7 @@ systemd:
           [Service]
           # Override Execstart in main unit
           ExecStart=
-          # Add new Execstart with `-` prefix to ignore failure`
+          # Add new Execstart with `-` prefix to ignore failure
           ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
     - name: issuegen-public-ipv4.service
       enabled: true

--- a/modules/ROOT/pages/tutorial-updates.adoc
+++ b/modules/ROOT/pages/tutorial-updates.adoc
@@ -108,7 +108,7 @@ Disconnect from the serial console by pressing `CTRL` + `]` and then use the rep
 
 As the system is not up to date, Zincati will notice this and will start updating the system. You should see the update process happening right away:
 
-NOTE: All necessary network services may not be up and running during the initial check. In such case Zincati will check for updates again in about 5 minutes.
+NOTE: All necessary network services may not be up and running during the initial check. In such a case, Zincati will check for updates again in about 5 minutes.
 
 ----
 [core@localhost ~]$ systemctl status --full zincati.service
@@ -268,7 +268,7 @@ Deployments:
              GPGSignature: Valid signature by 6A51BBABBA3D5467B6171221809A8D7CEB10B464
 ----
 
-And you can also verify that Zincati will not try to update to the new version we just rollbacked from:
+And you can also verify that Zincati will not try to update to the new version we just rolled back from:
 
 ----
 [core@localhost ~]$ systemctl status --full zincati.service

--- a/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
+++ b/modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc
@@ -1,6 +1,6 @@
 = Launching a user-level systemd unit on boot
 
-NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have create file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
+NOTE: Complete all the steps described in the xref:tutorial-setup.adoc[initial setup page] before starting this tutorial. Make sure you have created the file `ssh-key.pub` following the instructions provided in the https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-setup/#_ssh_public_key[prerequisites] for the tutorial. We will use this key in the Butane configuration file that we are about to write.
 
 In this tutorial, we will set up a user level systemd unit for an unprivileged user. There are times when it's helpful to launch a user-level https://www.freedesktop.org/software/systemd/man/systemd.unit.html[systemd unit] without having to log in. For example, you may wish to launch a container that provides a network service or run an HPC job. For this setup, we will add the following to a Butane config:
 

--- a/modules/ROOT/pages/update-barrier-signing-keys.adoc
+++ b/modules/ROOT/pages/update-barrier-signing-keys.adoc
@@ -6,7 +6,7 @@ All binary artifacts, ostree commits, and OS images belonging to Fedora and Fedo
 
 At the beginning of every new Fedora major release cycle, a new signing key is generated and its public portion published on the Fedora website. The new key will be later used to sign new artifacts, replacing the currently used one. This is done in order to establish an automatic chain of trust from an older release to a more recent one, which can be possibly signed by a different newer key.
 
-In order to make automatic updates of Fedora CoreOS work across major Fedora releases, the above set of embedded signing key is refreshed at least once per Fedora release cycle. When that happens, an update barrier is put in place in the FCOS update graph.
+In order to make automatic updates of Fedora CoreOS work across major Fedora releases, the above set of embedded signing keys is refreshed at least once per Fedora release cycle. When that happens, an update barrier is put in place in the FCOS update graph.
 
 The primary reason for such update barrier is to make sure that older (and possibly stale) instances automatically receive and trust newly generated keys. This is achieved by forcing such machines to progressively catch up on intermediate updates (signed by an already trusted key) before jumping to the latest published release.
 


### PR DESCRIPTION
This came out of an example session on AI usage.

Fix spelling errors, grammar issues, and unclear wording found during a comprehensive documentation review.

Assisted-by: OpenCode (claude-sonnet-4-20250514)