### PR TITLE
alternatives: Add warning and remove from sidebar

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -44,7 +44,6 @@
 ** xref:sysconfig-configure-swaponzram.adoc[Configuring SwapOnZRAM]
 ** xref:sysconfig-configure-wireguard.adoc[Configuring WireGuard]
 ** xref:kernel-args.adoc[Modifying Kernel Arguments]
-** xref:alternatives.adoc[Setting alternatives]
 ** xref:counting.adoc[Node counting]
 ** xref:time-zone.adoc[Configuring Time Zone]
 ** xref:grub-password.adoc[Setting a GRUB password]

--- a/modules/ROOT/pages/alternatives.adoc
+++ b/modules/ROOT/pages/alternatives.adoc
@@ -1,8 +1,18 @@
 = Setting alternatives
 
+[WARNING]
+====
+*Deprecated Content*
+
+This page documents the `iptables-legacy` alternative, which was *removed in Fedora CoreOS 43 and later*.
+The examples and instructions on this page are *no longer applicable* to current versions of Fedora CoreOS.
+This content is retained for historical reference only.
+====
+
 Due to an https://github.com/fedora-sysv/chkconfig/issues/9[ongoing issue] in how alternatives configurations are stored on the system, Fedora CoreOS systems can not use the usual `alternatives` commands to configure them.
 
-Instead, until this issue is resolved, you can set the symlinks directly in `/etc/alternatives`. For example, to use the legacy-based variants of the `iptables` commands:
+Instead, until this issue is resolved, you can set the symlinks directly in `/etc/alternatives`.
+For example, to use the legacy-based variants of the `iptables` commands:
 
 [source,yaml,subs="attributes"]
 ----
@@ -36,11 +46,11 @@ storage:
       hard: false
 ----
 
-== Using alternatives commands
+== Using `alternatives` commands
 
 Starting with Fedora CoreOS based on Fedora 41, you can use `alternatives` commands to configure the default command.
 
-.Example Butane config using a systemd unit to configure the default iptables backend
+.Example Butane config using a systemd unit to configure the default `iptables` backend
 [source,yaml,subs="attributes"]
 ----
 variant: fcos
@@ -59,21 +69,29 @@ systemd:
         WantedBy=multi-user.target
 ----
 
-NOTE: We don't recommend configuring the default iptables backend to `iptables-legacy`. This is just an example.
+[NOTE]
+====
+We don't recommend configuring the default `iptables` backend to `iptables-legacy`.
+This is just an example.
+====
 
 You can also manually run the `alternatives` commands to configure the default command runtime.
+The following examples demonstrate how to manually configure the default `iptables` backend. 
 
-.Example to manually configure the default iptables backend
-[source,bash]
+.Check the link info
+[source,console]
 ----
-# Check the link info
-alternatives --display iptables
-iptables --version
-
-# Configure iptables to point to iptables-nft
-sudo alternatives --set iptables /usr/sbin/iptables-nft
-
-# Verify iptables version is iptables-nft
-alternatives --display iptables
-iptables --version
+$ alternatives --display iptables
+$ iptables --version
+----
+.Configure iptables to point to iptables-nft
+[source,console]
+----
+$ sudo alternatives --set iptables /usr/sbin/iptables-nft
+----
+.Verify iptables version is iptables-nft
+[source,console]
+----
+$ alternatives --display iptables
+$ iptables --version
 ----

--- a/modules/ROOT/pages/alternatives.adoc
+++ b/modules/ROOT/pages/alternatives.adoc
@@ -11,8 +11,7 @@ This content is retained for historical reference only.
 
 Due to an https://github.com/fedora-sysv/chkconfig/issues/9[ongoing issue] in how alternatives configurations are stored on the system, Fedora CoreOS systems can not use the usual `alternatives` commands to configure them.
 
-Instead, until this issue is resolved, you can set the symlinks directly in `/etc/alternatives`.
-For example, to use the legacy-based variants of the `iptables` commands:
+Instead, until this issue is resolved, you can set the symlinks directly in `/etc/alternatives`. For example, to use the legacy-based variants of the `iptables` commands:
 
 [source,yaml,subs="attributes"]
 ----
@@ -46,11 +45,11 @@ storage:
       hard: false
 ----
 
-== Using `alternatives` commands
+== Using alternatives commands
 
 Starting with Fedora CoreOS based on Fedora 41, you can use `alternatives` commands to configure the default command.
 
-.Example Butane config using a systemd unit to configure the default `iptables` backend
+.Example Butane config using a systemd unit to configure the default iptables backend
 [source,yaml,subs="attributes"]
 ----
 variant: fcos
@@ -69,29 +68,21 @@ systemd:
         WantedBy=multi-user.target
 ----
 
-[NOTE]
-====
-We don't recommend configuring the default `iptables` backend to `iptables-legacy`.
-This is just an example.
-====
+NOTE: We don't recommend configuring the default iptables backend to `iptables-legacy`. This is just an example.
 
 You can also manually run the `alternatives` commands to configure the default command runtime.
-The following examples demonstrate how to manually configure the default `iptables` backend. 
 
-.Check the link info
-[source,console]
+.Example to manually configure the default iptables backend
+[source,bash]
 ----
-$ alternatives --display iptables
-$ iptables --version
-----
-.Configure iptables to point to iptables-nft
-[source,console]
-----
-$ sudo alternatives --set iptables /usr/sbin/iptables-nft
-----
-.Verify iptables version is iptables-nft
-[source,console]
-----
-$ alternatives --display iptables
-$ iptables --version
+# Check the link info
+alternatives --display iptables
+iptables --version
+
+# Configure iptables to point to iptables-nft
+sudo alternatives --set iptables /usr/sbin/iptables-nft
+
+# Verify iptables version is iptables-nft
+alternatives --display iptables
+iptables --version
 ----


### PR DESCRIPTION
Remove the alternatives page from the sidebar navigation as the iptables-legacy feature was removed in Fedora CoreOS 43. Add a deprecation warning at the top of the page to inform users that the content is out of date and no longer applicable.

The page content is retained for historical reference, but is no longer discoverable through the main navigation.

Improve AsciiDoc syntax and visual representation of the page.

Fixes: https://github.com/coreos/fedora-coreos-docs/issues/798

Assisted-by: Claude Haiku 4.5