### PR TITLE
provisioning (applehv): expand image and CoW tip

### DIFF
--- a/modules/ROOT/pages/provisioning-applehv.adoc
+++ b/modules/ROOT/pages/provisioning-applehv.adoc
@@ -35,6 +35,16 @@ This section shows how to boot a new VM with vfkit. Vfkit is known to work with 
 
 Fetch the latest image suitable for your target stream (or https://fedoraproject.org/coreos/download/[download and verify] it from the web).  Remember to download the appropriate image based on the architecture of your Mac.  Once downloaded, you will also need to decompress the image.
 
+TIP: If you want to keep a copy of the image file, use `cp` with the `-c` flag.
+
+[source, bash]
+```
+cp -c image.raw image.raw.original
+```
+
+This copies the file using clonefile(2), thus creating a Copy-on-Write (CoW) clone of the file.
+Less disk space will be used for storing the file `image.raw.original`.
+
 === Setting up a new VM
 
 Vfkit is not a stateful virtual machine framework. You simply need to run the vfkit binary to start a virtual machine. The following command line will launch a VM with:
@@ -73,3 +83,13 @@ When FCOS is completed booting, you will see the IP address of the VM displayed 
 ----
 ssh core@192.168.64.5
 ----
+
+=== Increasing disk size
+
+To have more free disk space available inside the image, you can increase the size of the image after downloading it.
+
+.Increase the size of the disk image by 10 GB
+[source, bash]
+```
+truncate -c -s +10G image.raw
+```


### PR DESCRIPTION
Add info about how to expand the image with `truncate`

Add tip about using `cp -c` to save disk space


### Rationale

I think the information could be useful.

Some extra info that is not included in the PR:
This how I usually handle an image file.

1. Download `image.raw.gz`
2. Uncompress
   ```
   gunzip image.raw.gz
   ```
3. Create dir
   ```
   mkdir backup
   ```
4. Create Copy-on-Write clone
   ```
   cp -c image.raw backup
   ```
5. Expand image
   ```
   truncate -c -s +10G image.raw
   ```
6. Start the vm with `vfkit`