### PR TITLE
storage: add boot_device.layout to mirror examples

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -191,6 +191,8 @@ If you want to replicate the boot disk across multiple drives for resiliency to 
 variant: fcos
 version: {butane-latest-stable-spec}
 boot_device:
+  # Change to match target architecture (aarch64, ppc64le, etc.)
+  layout: x86_64
   mirror:
     devices:
       - /dev/sda
@@ -506,6 +508,8 @@ This example configures a mirrored boot disk with a TPM2-encrypted root filesyst
 variant: fcos
 version: {butane-latest-stable-spec}
 boot_device:
+  # Change to match target architecture (aarch64, ppc64le, etc.)
+  layout: x86_64
   luks:
     tpm2: true
   mirror:


### PR DESCRIPTION
Starting with Butane spec 1.7.0, boot_device.layout is required when boot_device.mirror is specified (previously it was only a warning). Since the examples use {butane-latest-stable-spec} which resolves to 1.7.0, they now fail with:

  error at $.boot_device.mirror: boot_device.layout should be
  specified when boot_device.mirror is specified

Add layout: x86_64 to both examples that use boot_device.mirror, with a comment noting users should change this to match their target architecture.

Fixes: https://github.com/coreos/fedora-coreos-docs/issues/808

Assisted-by: <anthropic/claude-opus-4.6>