### PR TITLE
ci/check: Fix broken regexp and spec version replacement

### DIFF
--- a/ci/check.py
+++ b/ci/check.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# pylint: disable=missing-module-docstring
 #
 # Find all Butane configs in the doc tree, use the podman Butane container
 # to run them through butane --strict, and fail on any errors.
@@ -36,6 +37,7 @@ parser.add_argument('-v', '--verbose', action='store_true',
 args = parser.parse_args()
 
 def handle_error(e):
+    # pylint: disable=missing-function-docstring
     raise e
 
 # Arbitrary number (current number of tests) to set a bar where we should
@@ -47,13 +49,15 @@ tested_config_count = 0
 tmpfiles = {
     # tutorial-services.adoc
     os.path.join('public-ipv4.sh'): '#!/bin/bash\ntrue',
-    os.path.join('issuegen-public-ipv4.service'): '[Unit]\nBefore=systemd-user-sessions.service\n[Install]\nWantedBy=multi-user.target',
+    os.path.join('issuegen-public-ipv4.service'):
+        '[Unit]\nBefore=systemd-user-sessions.service\n[Install]\nWantedBy=multi-user.target',
     # authentication.adoc
     os.path.join('users', 'core', 'id_rsa.pub'): 'ssh-rsa AAAAB',
     os.path.join('users', 'jlebon', 'id_rsa.pub'): 'ssh-rsa AAAAB',
     os.path.join('users', 'jlebon', 'id_ed25519.pub'): 'ssh-ed25519 AAAAC',
     os.path.join('users', 'miabbott', 'id_rsa.pub'): 'ssh-rsa AAAAB',
-    # tutorial-containers.adoc, tutorial-setup.adoc, tutorial-updates.adoc, tutorial-user-systemd-unit-on-boot.adoc
+    # tutorial-containers.adoc, tutorial-setup.adoc, tutorial-updates.adoc,
+    # tutorial-user-systemd-unit-on-boot.adoc
     os.path.join('ssh-key.pub'): 'ssh-rsa AAAAB',
 }
 
@@ -69,7 +73,7 @@ ret = 0
 with tempfile.TemporaryDirectory() as tmpdocs:
     for path, contents in tmpfiles.items():
         os.makedirs(os.path.join(tmpdocs, os.path.dirname(path)), exist_ok=True)
-        with open(os.path.join(tmpdocs, path), 'w') as fh:
+        with open(os.path.join(tmpdocs, path), 'w', encoding="utf-8") as fh:
             fh.write(contents)
     for dirpath, dirnames, filenames in os.walk('.', onerror=handle_error):
         dirnames.sort()  # walk in sorted order
@@ -77,7 +81,7 @@ with tempfile.TemporaryDirectory() as tmpdocs:
             filepath = os.path.join(dirpath, filename)
             if not filename.endswith('.adoc'):
                 continue
-            with open(filepath) as fh:
+            with open(filepath, encoding="utf-8") as fh:
                 filedata = fh.read()
             # Iterate over YAML source blocks
             for match in matcher.finditer(filedata):
@@ -99,7 +103,8 @@ with tempfile.TemporaryDirectory() as tmpdocs:
                     universal_newlines=True,  # can be spelled "text" on >= 3.7
                     input=bu,
                     stdout=subprocess.DEVNULL,
-                    stderr=subprocess.PIPE)
+                    stderr=subprocess.PIPE,
+                    check=False)
                 if result.returncode != 0:
                     formatted = textwrap.indent(result.stderr.strip(), '  ')
                     # Not necessary for ANSI terminals, but required by GitHub's

--- a/ci/check.py
+++ b/ci/check.py
@@ -52,6 +52,14 @@ tmpfiles = {
     os.path.join('ssh-key.pub'): 'ssh-rsa AAAAB',
 }
 
+# Get spec version from antora.yml
+with open("antora.yml", encoding="utf-8") as stream:
+    try:
+        antora = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+butane_latest_spec = antora.get("asciidoc").get("attributes").get("butane-latest-stable-spec")
+
 ret = 0
 with tempfile.TemporaryDirectory() as tmpdocs:
     for path, contents in tmpfiles.items():
@@ -69,6 +77,7 @@ with tempfile.TemporaryDirectory() as tmpdocs:
             # Iterate over YAML source blocks
             for match in matcher.finditer(filedata):
                 bu = match.group(1)
+                bu = bu.replace('{butane-latest-stable-spec}', butane_latest_spec)
                 buline = filedata.count('\n', 0, match.start(1)) + 1
                 if not bu.startswith('variant:'):
                     print(f'{WARN}Ignoring non-Butane YAML at {filepath}:{buline}{RESET}')

--- a/ci/check.py
+++ b/ci/check.py
@@ -38,6 +38,10 @@ args = parser.parse_args()
 def handle_error(e):
     raise e
 
+# Arbitrary number (current number of tests) to set a bar where we should
+# verify that the CI still works
+EXPECTED_CONFIG_COUNT = 99
+tested_config_count = 0
 
 # List of files required during verification
 tmpfiles = {
@@ -98,4 +102,11 @@ with tempfile.TemporaryDirectory() as tmpdocs:
                     formatted = ERR + formatted.replace('\n', '\n' + ERR)
                     print(f'{ERR}Invalid Butane config at {filepath}:{buline}:\n{formatted}{RESET}')
                     ret = 1
+                tested_config_count += 1
+
+if tested_config_count < EXPECTED_CONFIG_COUNT:
+    print(f'Only {tested_config_count} configs tested ({EXPECTED_CONFIG_COUNT} expected).')
+    print('Something likely went wrong. Check this script!')
+    ret = 1
+
 sys.exit(ret)

--- a/ci/check.py
+++ b/ci/check.py
@@ -90,7 +90,12 @@ with tempfile.TemporaryDirectory() as tmpdocs:
                 if args.verbose:
                     print(f'Checking Butane config at {filepath}:{buline}')
                 result = subprocess.run(
-                    ['podman', 'run', '--rm', '-i', '-v=' + tmpdocs + ':/files-dir', container, '--strict', '--files-dir=/files-dir'],
+                        ['podman', 'run',
+                         '--rm', '--interactive',
+                         '--security-opt', 'label=disable',
+                         '--volume=' + tmpdocs + ':/files-dir',
+                         container,
+                         '--strict', '--files-dir=/files-dir'],
                     universal_newlines=True,  # can be spelled "text" on >= 3.7
                     input=bu,
                     stdout=subprocess.DEVNULL,

--- a/ci/check.py
+++ b/ci/check.py
@@ -20,13 +20,14 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import yaml
 
 ERR = '\x1b[1;31m'
 WARN = '\x1b[1;33m'
 RESET = '\x1b[0m'
 
 container = os.getenv('BUTANE_CONTAINER', 'quay.io/coreos/butane:release')
-matcher = re.compile(r'^\[source,\s*yaml\]\n----\n(.+?\n)----$',
+matcher = re.compile(r'^\[source,yaml,subs="attributes"\]\n----\n(.+?\n)----$',
         re.MULTILINE | re.DOTALL)
 
 parser = argparse.ArgumentParser(description='Run validations on docs.')

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -98,6 +98,7 @@ storage:
     partitions:
     - size_mib: 0
       start_mib: 0
+      number: 1
       label: log
   filesystems:
     - path: /var/log

--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -191,6 +191,8 @@ If you want to replicate the boot disk across multiple drives for resiliency to 
 variant: fcos
 version: {butane-latest-stable-spec}
 boot_device:
+  # Change to match target architecture (aarch64, ppc64le, etc.)
+  layout: x86_64
   mirror:
     devices:
       - /dev/sda
@@ -506,6 +508,8 @@ This example configures a mirrored boot disk with a TPM2-encrypted root filesyst
 variant: fcos
 version: {butane-latest-stable-spec}
 boot_device:
+  # Change to match target architecture (aarch64, ppc64le, etc.)
+  layout: x86_64
   luks:
     tpm2: true
   mirror:

--- a/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
+++ b/modules/ROOT/pages/sysconfig-configure-wireguard.adoc
@@ -86,7 +86,7 @@ storage:
 If you want to use the support in NetworkManager, you can import the WireGuard configuration with a oneshot unit:
 
 .Example systemd service unit to import the WireGuard configuration
-[source,yaml,subs="attributes"]
+[source,yaml]
 ----
 systemd:
   units:
@@ -127,7 +127,7 @@ Connection 'wg0' (18cd8e61-1cc2-43a2-9f2e-467b75cd99da) successfully added.
 
 If you want to use `wg-quick` instead of the support in NetworkManager, you can add the following to your Butane config:
 
-[source,yaml,subs="attributes"]
+[source,yaml]
 ----
 systemd:
   units:


### PR DESCRIPTION
ci/check: Replace spec version attribute in config snippets

In [1], I replaced all hardcoded FCOS Butane spec versions by an
AsciiDoc document attribute that is dynamically replaced when generating
the docs.

This attribute is however not replaced when we run the script to check
the configurations snippets in the documentation as we process the
source documentation files. Thus we need to manually do the
substitution.

[1] https://github.com/coreos/fedora-coreos-docs/pull/612

Fixes: https://github.com/coreos/fedora-coreos-docs/pull/612

---

ci/check: Fix regexp used to extract Butane config snippets

In [1], I replaced all hardcoded FCOS Butane spec versions by an
AsciiDoc document attribute that is dynamically replaced when generating
the docs. Attributes are not replaced by default in source snippets in
AsciiDoc so I had to set the `subs="attributes"` option on those
snippets.

The script that checks Butane config snippets in the docs relies on a
regexp to find the config snippets and extract them for validation. With
the change in [1], the regexp did not match anymore and no configuration
was thus checked anymore.

Thus update the regexp to match the added attribute to Butane config
source snippets.

[1] https://github.com/coreos/fedora-coreos-docs/pull/612

---

ci/check: Fail if less than expected number of configs have been tested

In [1], I realized that CI was silently broken since [2] as we
dynamically generate our test cases from config snippets in the docs
using a regular expression match that did not match anymore with the
changes in [2].

Thus count the number of configs checked by this script and fail if it's
under an arbitrary number, which the current number of config that we
test. We don't strictly need to increase this number as we add tests and
we can decrease it if we ever reduce the number of tests cases.

[1] https://github.com/coreos/fedora-coreos-docs/pull/809
[2] https://github.com/coreos/fedora-coreos-docs/pull/612

Fixes: https://github.com/coreos/fedora-coreos-docs/pull/612

---

ci/check: Run Butane container with SELinux isolation

Match how we recommend running Butane from a container in the documentation:
https://coreos.github.io/butane/getting-started/#getting-butane

Fixes the following errors:

```
Invalid Butane config at ./modules/ROOT/pages/authentication.adoc:55:
  error at $.passwd.users.0.ssh_authorized_keys_local.0, line 7 col 11: open /files-dir/users/core/id_rsa.pub: permission denied
  error at $.passwd.users.1.ssh_authorized_keys_local.0, line 10 col 11: open /files-dir/users/jlebon/id_rsa.pub: permission denied
  error at $.passwd.users.1.ssh_authorized_keys_local.1, line 11 col 11: open /files-dir/users/jlebon/id_ed25519.pub: permission denied
  error at $.passwd.users.2.ssh_authorized_keys_local.0, line 14 col 11: open /files-dir/users/miabbott/id_rsa.pub: permission denied
  Error translating config: source config is invalid

Invalid Butane config at ./modules/ROOT/pages/tutorial-containers.adoc:22:
  error at $.passwd.users.0.ssh_authorized_keys_local.0, line 7 col 11: open /files-dir/ssh-key.pub: permission denied
  Error translating config: source config is invalid

Invalid Butane config at ./modules/ROOT/pages/tutorial-services.adoc:59:
  error at $.storage.files.2.contents.local, line 33 col 16: open /files-dir/public-ipv4.sh: permission denied
  error at $.systemd.units.1.contents_local, line 16 col 23: open /files-dir/issuegen-public-ipv4.service: permission denied
  Error translating config: source config is invalid

Invalid Butane config at ./modules/ROOT/pages/tutorial-updates.adoc:53:
  error at $.passwd.users.0.ssh_authorized_keys_local.0, line 7 col 11: open /files-dir/ssh-key.pub: permission denied
  Error translating config: source config is invalid

Invalid Butane config at ./modules/ROOT/pages/tutorial-user-systemd-unit-on-boot.adoc:121:
  error at $.passwd.users.0.ssh_authorized_keys_local.0, line 7 col 11: open /files-dir/ssh-key.pub: permission denied
  Error translating config: source config is invalid
```

---

ci/check: Fix minor Python lints

- Ignore missing docstrings
- Open files as UTF-8
- Split some long lines
- Make it explicit that we don't need the subprocess function to check
  the return code as we will do it ourselves right after

---

wireguard: Drop some attributes substitution

Those configuration snippets are not full Butane configs and they do not
include any AsciiDoc attribute to replace, thus this option is not
needed and we don't need to validate them.

---

storage: add boot_device.layout to mirror examples

Starting with Butane spec 1.7.0, boot_device.layout is required when
boot_device.mirror is specified (previously it was only a warning).
Since the examples use {butane-latest-stable-spec} which resolves to
1.7.0, they now fail with:

  error at $.boot_device.mirror: boot_device.layout should be
  specified when boot_device.mirror is specified

Add layout: x86_64 to both examples that use boot_device.mirror, with
a comment noting users should change this to match their target
architecture.

Fixes: https://github.com/coreos/fedora-coreos-docs/issues/808

Assisted-by: <anthropic/claude-opus-4.6>

---

storage: Fix `/var` partition re-use example

Fixes:

```
Invalid Butane config at ./modules/ROOT/pages/storage.adoc:92:
  warning at $.storage.disks.0.partitions.0.number, line 8 col 7: partitions cannot be reused by label; number must be specified except on boot disk (/dev/disk/by-id/coreos-boot-disk) or when wipe_table is true
  Config produced warnings and --strict was specified
```

See: https://github.com/coreos/butane/pull/711#issuecomment-4631845582