### PR TITLE
provisioning: Update requirements for Ignition configs

### DIFF
--- a/modules/ROOT/pages/getting-started.adoc
+++ b/modules/ROOT/pages/getting-started.adoc
@@ -21,6 +21,10 @@ Each platform has specific logic to retrieve and apply the first boot configurat
 
 For more information on configuration, refer to the documentation for xref:producing-ign.adoc[Producing an Ignition File].
 
+NOTE: While we recommend using Ignition to configure Fedora CoreOS, it is not required to get started
+      using Fedora CoreOS on most platforms. You can use the platform native SSH key configuration
+      mechanisms instead to configure access to your system.
+
 == Quickstart
 
 === Booting on a cloud VM (AWS example)

--- a/modules/ROOT/pages/provisioning-afterburn.adoc
+++ b/modules/ROOT/pages/provisioning-afterburn.adoc
@@ -1,0 +1,6 @@
+:page-partial:
+
+Fedora CoreOS supports configuring access via SSH keys using https://coreos.github.io/afterburn/platforms/[Afterburn] on this platform.
+Once you have configured your SSH Key in the platform configuration, you can provision and access Fedora CoreOS instances with the default user `core`, without using an Ignition config.
+
+We recommend xref:producing-ign.adoc[using an Ignition config] once you are more familiar with Fedora CoreOS and want to automate the deployment of systems.

--- a/modules/ROOT/pages/provisioning-aliyun.adoc
+++ b/modules/ROOT/pages/provisioning-aliyun.adoc
@@ -4,13 +4,9 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Alibaba Clou
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an Alibaba Cloud account and https://www.alibabacloud.com/help/doc-detail/31884.htm?spm=a2c63.p38356.879954.10.3d1264baRYHfmB#task-njz-hf4-tdb[activated Object Storage Service (OSS)].
+You need to have access to an Alibaba Cloud account and https://www.alibabacloud.com/help/doc-detail/31884.htm?spm=a2c63.p38356.879954.10.3d1264baRYHfmB#task-njz-hf4-tdb[activated Object Storage Service (OSS)].
 The examples below use the https://www.alibabacloud.com/help/product/29991.htm[Alibaba Cloud CLI] and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 
 == Downloading an Alibaba Cloud image

--- a/modules/ROOT/pages/provisioning-aws.adoc
+++ b/modules/ROOT/pages/provisioning-aws.adoc
@@ -4,13 +4,10 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on the Amaz
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an AWS account. The examples below use the https://aws.amazon.com/cli/[aws] command-line tool, which must be separately installed and configured beforehand.
+You need to have access to an AWS account.
+The examples below use the https://aws.amazon.com/cli/[aws] command-line tool, which must be separately installed and configured beforehand.
 
 == Launching a VM instance
 

--- a/modules/ROOT/pages/provisioning-azure.adoc
+++ b/modules/ROOT/pages/provisioning-azure.adoc
@@ -6,13 +6,10 @@ NOTE: FCOS does not support legacy https://learn.microsoft.com/en-us/azure/virtu
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an Azure subscription. The examples below use the https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest[Azure CLI].
+You need to have access to an Azure subscription.
+The examples below use the https://docs.microsoft.com/en-us/cli/azure/?view=azure-cli-latest[Azure CLI].
 
 == Downloading an Azure image
 

--- a/modules/ROOT/pages/provisioning-digitalocean.adoc
+++ b/modules/ROOT/pages/provisioning-digitalocean.adoc
@@ -4,13 +4,10 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on DigitalOcean
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to a DigitalOcean account. The examples below use the https://github.com/digitalocean/doctl[doctl] command-line tool and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
+You need to have access to a DigitalOcean account.
+The examples below use the https://github.com/digitalocean/doctl[doctl] command-line tool and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 
 == Creating a DigitalOcean custom image
 

--- a/modules/ROOT/pages/provisioning-exoscale.adoc
+++ b/modules/ROOT/pages/provisioning-exoscale.adoc
@@ -4,13 +4,10 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on https://
 
 == Prerequisites
 
-Before provisioning an FCOS machine, it is recommended to have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an Exoscale account. https://portal.exoscale.com/register[Register] if you don't have one.
+You need to have access to an Exoscale account.
+https://portal.exoscale.com/register[Register] if you don't have one.
 
 == Uploading an FCOS image as a custom Template
 

--- a/modules/ROOT/pages/provisioning-gcp.adoc
+++ b/modules/ROOT/pages/provisioning-gcp.adoc
@@ -4,13 +4,10 @@ This guide shows how to provision new Fedora CoreOS (FCOS) instances on Google C
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to a GCP account. The examples below use the https://cloud.google.com/sdk/gcloud[gcloud] command-line tool, which must be separately installed and configured beforehand.
+You need to have access to a GCP account.
+The examples below use the https://cloud.google.com/sdk/gcloud[gcloud] command-line tool, which must be separately installed and configured beforehand.
 
 == Selecting an image family
 

--- a/modules/ROOT/pages/provisioning-hetzner.adoc
+++ b/modules/ROOT/pages/provisioning-hetzner.adoc
@@ -18,15 +18,9 @@ IMPORTANT: In order to create a snapshot, the https://github.com/apricote/hcloud
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations.
-If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS.
-      If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support] and only configure SSH keys.
-
-You also need to have access to a Hetzner account.
+You need to have access to a Hetzner account.
 The examples below use the https://github.com/hetznercloud/cli[hcloud] command-line tool, the https://github.com/apricote/hcloud-upload-image[hcloud-upload-image] tool and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 
 == Downloading a Hetzner image

--- a/modules/ROOT/pages/provisioning-ibmcloud.adoc
+++ b/modules/ROOT/pages/provisioning-ibmcloud.adoc
@@ -6,14 +6,13 @@ NOTE: FCOS does not support https://cloud.ibm.com/docs/cloud-infrastructure?topi
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an https://cloud.ibm.com/login[IBM Cloud account]. The examples below use the https://cloud.ibm.com/docs/cli?topic=cli-getting-started[`ibmcloud`] command-line tool, which must be separately installed and configured beforehand.
-Follow the directions at https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli to install the ibmcloud CLI. You'll need both the `cloud-object-storage` and `infrastructure-service` plugins installed. This can be done with:
+You need to have access to an https://cloud.ibm.com/login[IBM Cloud account].
+The examples below use the https://cloud.ibm.com/docs/cli?topic=cli-getting-started[`ibmcloud`] command-line tool, which must be separately installed and configured beforehand.
+Follow the directions at https://cloud.ibm.com/docs/cli?topic=cli-install-ibmcloud-cli to install the ibmcloud CLI.
+You'll need both the `cloud-object-storage` and `infrastructure-service` plugins installed.
+This can be done with:
 
  * `ibmcloud plugin install cloud-object-storage`
  * `ibmcloud plugin install infrastructure-service`

--- a/modules/ROOT/pages/provisioning-openstack.adoc
+++ b/modules/ROOT/pages/provisioning-openstack.adoc
@@ -7,18 +7,13 @@ The steps below were tested against the OpenStack Victoria release.
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an OpenStack environment and a functioning
+You need to have access to an OpenStack environment and a functioning
 https://docs.openstack.org/python-designateclient/latest/user/shell-v2.html[`openstack` CLI].
-Typically, you'll https://docs.openstack.org/python-openstackclient/latest/configuration/index.html[configure the client]
-by using a `clouds.yaml` file or via environment variables. If you're starting from scratch, this
-environment may need networks, SSH key pairs, security groups, etc.. set up. Please consult the
-https://docs.openstack.org/[OpenStack Documentation] to learn more.
+Typically, you'll https://docs.openstack.org/python-openstackclient/latest/configuration/index.html[configure the client] by using a `clouds.yaml` file or via environment variables.
+If you're starting from scratch, this environment may need networks, SSH key pairs, security groups, etc... set up.
+Please consult the https://docs.openstack.org/[OpenStack Documentation] to learn more.
 
 == Downloading an OpenStack Image
 

--- a/modules/ROOT/pages/provisioning-oraclecloud.adoc
+++ b/modules/ROOT/pages/provisioning-oraclecloud.adoc
@@ -6,15 +6,9 @@ Thus you must first download the Fedora CoreOS image for Oracle Cloud Infrastruc
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations.
-If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS.
-      If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to an Oracle Cloud Infrastructure account.
+You need to have access to an Oracle Cloud Infrastructure account.
 The examples below use the https://docs.oracle.com/en-us/iaas/Content/API/Concepts/cliconcepts.htm[oci] command-line tool and https://stedolan.github.io/jq/[jq] as a command-line JSON processor.
 
 IMPORTANT: This guide currently only covers Virtual Machine shapes and not Bare Metal ones.

--- a/modules/ROOT/pages/provisioning-vultr.adoc
+++ b/modules/ROOT/pages/provisioning-vultr.adoc
@@ -4,13 +4,11 @@ This guide shows how to provision new Fedora CoreOS (FCOS) nodes on Vultr. Vultr
 
 == Prerequisites
 
-Before provisioning an FCOS machine, you must have an Ignition configuration file containing your customizations. If you do not have one, see xref:producing-ign.adoc[Producing an Ignition File].
+include::provisioning-afterburn.adoc[]
 
-NOTE: Fedora CoreOS has a default `core` user that can be used to explore the OS. If you want to use it, finalize its xref:authentication.adoc[configuration] by providing e.g. an SSH key.
-
-If you do not want to use Ignition to get started, you can make use of the https://coreos.github.io/afterburn/platforms/[Afterburn support].
-
-You also need to have access to a Vultr account. The examples below use the https://github.com/vultr/vultr-cli[vultr-cli] and https://s3tools.org/s3cmd[s3cmd] command-line tools. Both of these tools are available in Fedora and can be installed via `sudo dnf install vultr-cli s3cmd`.
+You need to have access to a Vultr account.
+The examples below use the https://github.com/vultr/vultr-cli[vultr-cli] and https://s3tools.org/s3cmd[s3cmd] command-line tools.
+Both of these tools are available in Fedora and can be installed via `sudo dnf install vultr-cli s3cmd`.
 
 == Using a custom snapshot
 


### PR DESCRIPTION
Clearly note that the user can start and access an instance without providing an Ignition config on the platforms where we have Afterburn support.

Fixes: https://github.com/coreos/fedora-coreos-docs/issues/748