### PR TITLE
customizing-nic: update docs about ifname kernel argument

### DIFF
--- a/modules/ROOT/pages/customize-nic.adoc
+++ b/modules/ROOT/pages/customize-nic.adoc
@@ -42,9 +42,7 @@ storage:
 == Networking in the Initramfs via Kernel Arguments
 If networking in the initramfs is required, the kernel argument `ifname=` will dynamically create a udev rule to change the name of a NIC.
 
-Currently, unlike other parts of the networking config from the initramfs (e.g. static IPs, hostnames, etc.), these udev rules are not persisted into the real root. If the custom name needs to be applied to the real root, either a link file or udev rule must be created, as shown above. See https://github.com/coreos/fedora-coreos-tracker/issues/553[this issue] for more details.
-
-For example, to give the NIC with the MAC address `12:34:56:78:9a:bc` a name of "infra", provide a `ifname=infra:12:34:56:78:9a:bc` kernel argument. A udev rule would be created in the initramfs like:
+For example, to give the NIC with the MAC address `12:34:56:78:9a:bc` a name of "infra", provide a `ifname=infra:12:34:56:78:9a:bc` kernel argument. A udev rule will be created like:
 [source]
 ----
 # cat /etc/udev/rules.d/80-ifname.rules


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/553 was fixed some time ago so we can update the docs here.