### PR TITLE
docs: correct systemd automount example

### DIFF
--- a/modules/ROOT/pages/storage.adoc
+++ b/modules/ROOT/pages/storage.adoc
@@ -482,9 +482,6 @@ systemd:
         Where=/var/mnt/data
         Type=nfs4
 
-        [Install]
-        WantedBy=multi-user.target
-
     - name: var-mnt-data.automount
       enabled: true
       contents: |
@@ -498,6 +495,8 @@ systemd:
         [Install]
         WantedBy=multi-user.target
 ----
+
+Only the `.automount` unit is enabled. It activates the `.mount` unit on demand when the mount point is accessed.
 
 == Advanced examples
 


### PR DESCRIPTION
## Summary

- remove the Install section from the mount unit in the automount example
- clarify that the automount unit activates the mount unit on demand

The mount unit is intended to be activated by the automount unit. Providing an Install section suggests that users can enable the mount unit directly, bypassing the documented on-demand behavior.

Fixes #823

## Testing

- `ci/check.py -v`
- Antora documentation build with the official Fedora UI bundle
